### PR TITLE
fix(auth): ログイン後にマイページで認証状態が共有されない問題を修正

### DIFF
--- a/public/auth.html
+++ b/public/auth.html
@@ -63,13 +63,13 @@ body{font-family:'Noto Sans JP',sans-serif;background:var(--bg);color:var(--text
 
 <script type="module">
 import { initializeApp, getApps }
-  from 'https://www.gstatic.com/firebasejs/10.8.0/firebase-app.js'
+  from 'https://www.gstatic.com/firebasejs/11.6.0/firebase-app.js'
 import { getAuth, createUserWithEmailAndPassword, signInWithEmailAndPassword,
          onAuthStateChanged, sendPasswordResetEmail,
          browserSessionPersistence, setPersistence }
-  from 'https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js'
+  from 'https://www.gstatic.com/firebasejs/11.6.0/firebase-auth.js'
 import { getFirestore, doc, setDoc, getDoc, serverTimestamp }
-  from 'https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js'
+  from 'https://www.gstatic.com/firebasejs/11.6.0/firebase-firestore.js'
 
 // window.FIREBASE_CONFIG は上の <script src="..."> で設定済み
 if (!window.FIREBASE_CONFIG || window.FIREBASE_CONFIG.apiKey.includes('YOUR_')) {
@@ -82,7 +82,7 @@ const FIREBASE_CONFIG = window.FIREBASE_CONFIG
 
 const BASE = '/mito1-digital-studenthandbook'
 
-const app  = getApps().find(a => a.name === 'auth-page') || initializeApp(FIREBASE_CONFIG, 'auth-page')
+const app  = getApps().length ? getApps()[0] : initializeApp(FIREBASE_CONFIG)
 const auth = getAuth(app)
 const db   = getFirestore(app)
 


### PR DESCRIPTION
## 修正内容

### 1. 認証セッション共有の修正 (auth.html)
- `auth.html` が `'auth-page'` という別名で Firebase App を初期化していたため、`index.html` の `[DEFAULT]` アプリとセッションが共有されなかった問題を修正
- Firebase CDN バージョンを v10.8.0 → v11.6.0 に更新

### 2. メール送信エラーハンドリングの改善 (cases.js)
- `sendEmail()` ヘルパー関数を追加し、すべての fetch をラップ
- メール送信失敗（Resend ドメイン未検証の 403 エラー等）でもケース作成は成功させる
- メール送信失敗時にはユーザーに警告メッセージを表示（「顧問の先生に直接ご連絡ください」）
- `createCase()` の返り値を `{ caseId, emailSent }` に変更

### 3. マイページ：申請取り下げ機能 (index.html, cases.js)
- 顧問承認前（`pending_supervisor`）の申請に「申請を取り下げる」ボタンを追加
- `deleteCaseByStudent()` で `studentId` と `status` を検証し、不正な削除を防止

### 4. 管理者ダッシュボード：ケース削除機能 (admin/main.js)
- 全ステータスのケースに「削除」ボタンを追加
- `deleteDoc` で直接 Firestore から削除

## テスト
- [x] ログイン → auth.html → マイページでログイン状態が維持される
- [x] 公欠申請 → メール送信失敗時に警告が表示される（ケースは保存される）
- [x] マイページ → 顧問承認前の申請に「取り下げ」ボタンが表示され、削除可能
- [x] マイページ → 顧問承認後の申請には「取り下げ」ボタンが表示されない
- [x] 管理者ダッシュボード → 全ケースに「削除」ボタンが表示され、削除可能