### PR TITLE
feat: メール送信エラーハンドリング・マイページ申請取り下げ・管理者ケース削除

### DIFF
--- a/index.html
+++ b/index.html
@@ -2205,7 +2205,7 @@ import { loadAllData } from '/src/main.js'
 import { db } from '/src/firebase.js'
 import { collection, addDoc, serverTimestamp } from 'firebase/firestore'
 import { onAuth, getCurrentProfile, logout } from '/src/auth.js'
-import { createCase, getMyCases } from '/src/cases.js'
+import { createCase, getMyCases, deleteCaseByStudent } from '/src/cases.js'
 
 loadAllData().catch(e => console.error('[Firestore]', e))
 
@@ -2342,7 +2342,7 @@ window.submitApply = async function() {
   btn.textContent = '送信中...'
 
   try {
-    await createCase({
+    const result = await createCase({
       studentId:      _currentUser.uid,
       studentName:    (_currentProfile && _currentProfile.name) || _currentUser.email,
       studentEmail:   _currentUser.email,
@@ -2350,6 +2350,17 @@ window.submitApply = async function() {
     })
     document.getElementById('applyForm').style.display = 'none'
     document.getElementById('applyDone').style.display = ''
+    // メール送信失敗時の注意表示
+    if (!result.emailSent) {
+      const notice = document.getElementById('applyDone').querySelector('.email-warn')
+      if (!notice) {
+        const warn = document.createElement('div')
+        warn.className = 'email-warn'
+        warn.style.cssText = 'font-size:12px;color:#856404;background:#fff3cd;padding:10px 14px;border-radius:8px;margin-top:12px;text-align:left'
+        warn.innerHTML = '⚠️ 顧問への承認依頼メールの自動送信に失敗しました。<br>申請データは保存済みです。顧問の先生に直接ご連絡ください。'
+        document.getElementById('applyDone').querySelector('.card').appendChild(warn)
+      }
+    }
   } catch(e) {
     showErr('送信に失敗しました: ' + e.message)
     btn.disabled = false
@@ -2422,6 +2433,7 @@ window.loadMyCases = async function() {
         { label:'完了',     done: st==='approved',                                  active: false },
       ]
       const rejected = st === 'rejected'
+      const canDelete = st === 'pending_supervisor'
 
       const progressBar = rejected
         ? `<div style="margin:12px 0;font-size:11.5px;color:#721c24;background:#f8d7da;padding:8px 12px;border-radius:6px">
@@ -2435,6 +2447,16 @@ window.loadMyCases = async function() {
                </div>`).join('')}
            </div>`
 
+      const deleteBtn = canDelete
+        ? `<div style="margin-top:10px;padding-top:10px;border-top:1px solid var(--border);display:flex;justify-content:flex-end">
+             <button onclick="deleteMyCaseBtn('${c.id}')"
+               style="font-size:11.5px;padding:6px 14px;border:1.5px solid var(--enjii);border-radius:7px;background:transparent;color:var(--enjii);cursor:pointer;font-family:inherit;font-weight:500;transition:background .15s"
+               onmouseover="this.style.background='var(--enjii-bg)'" onmouseout="this.style.background='transparent'">
+               申請を取り下げる
+             </button>
+           </div>`
+        : ''
+
       return `
         <div style="background:var(--surface);border:1.5px solid var(--border);border-radius:var(--r);padding:18px 20px;margin-bottom:12px">
           <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;flex-wrap:wrap">
@@ -2444,6 +2466,7 @@ window.loadMyCases = async function() {
           <div style="font-size:15px;font-weight:600;color:var(--text);margin-bottom:4px">${c.title||''}</div>
           <div style="font-size:12px;color:var(--text-3);margin-bottom:2px">${c.reason||''} ／ 📅 ${datesStr}</div>
           ${progressBar}
+          ${deleteBtn}
         </div>`
     }).join('')
   } catch(e) {
@@ -2465,6 +2488,18 @@ window.doLogoutFront = async function() {
   _currentProfile = null
   updateAuthUI()
   nav('home')
+}
+
+// マイページ：申請取り下げ
+window.deleteMyCaseBtn = async function(caseId) {
+  if (!_currentUser) { alert('ログインが必要です'); return }
+  if (!confirm('この申請を取り下げますか？\nこの操作は取り消せません。')) return
+  try {
+    await deleteCaseByStudent(caseId, _currentUser.uid)
+    window.loadMyCases()
+  } catch(e) {
+    alert('削除に失敗しました: ' + e.message)
+  }
 }
 </script>
 </body>

--- a/src/admin/main.js
+++ b/src/admin/main.js
@@ -962,9 +962,28 @@ window.loadAdminCases = async function() {
           <div style="font-size:12px;color:var(--text-3);margin-bottom:2px">公欠日: ${escHtml(datesStr)} ／ 事由: ${escHtml(c.reason||'')}</div>
           <div style="font-size:11.5px;color:var(--text-3)">顧問: ${escHtml(c.supervisorEmail||'')} ／ 担任: ${escHtml(c.homeRoomEmail||'')}</div>
           ${progressBar}
+          <div style="margin-top:10px;padding-top:10px;border-top:1px solid var(--border);display:flex;justify-content:flex-end">
+            <button onclick="deleteAdminCase('${c.id}')"
+              style="font-size:11px;padding:5px 12px;border:1px solid #e74c3c;border-radius:6px;background:transparent;cursor:pointer;color:#e74c3c;font-family:inherit;transition:background .15s"
+              onmouseover="this.style.background='#fdf0f0'" onmouseout="this.style.background='transparent'">
+              削除
+            </button>
+          </div>
         </div>`
     }).join('')
   } catch(e) {
     el.innerHTML = `<div style="padding:20px;color:#c0392b">読み込みエラー: ${e.message}</div>`
+  }
+}
+
+// 管理者：ケース削除
+window.deleteAdminCase = async function(caseId) {
+  if (!confirm('このケースを削除しますか？\nこの操作は取り消せません。')) return
+  try {
+    await deleteDoc(doc(db, 'cases', caseId))
+    showToast('ケースを削除しました')
+    loadAdminCases()
+  } catch(e) {
+    alert('削除に失敗しました: ' + e.message)
   }
 }

--- a/src/cases.js
+++ b/src/cases.js
@@ -1,10 +1,10 @@
 /**
  * src/cases.js
- * 公欠申請（ケース）の作成・取得・承認ロジック
+ * 公欠申請（ケース）の作成・取得・承認・削除ロジック
  */
 import { db } from './firebase.js'
 import {
-  collection, doc, addDoc, updateDoc, getDoc, getDocs,
+  collection, doc, addDoc, updateDoc, getDoc, getDocs, deleteDoc,
   query, where, orderBy, serverTimestamp,
 } from 'firebase/firestore'
 
@@ -18,6 +18,28 @@ function genToken() {
   const arr = new Uint8Array(24)
   crypto.getRandomValues(arr)
   return Array.from(arr, b => b.toString(16).padStart(2,'0')).join('')
+}
+
+// =============================================
+// メール送信ヘルパー（エラーをキャッチして返す）
+// =============================================
+async function sendEmail(endpoint, payload) {
+  try {
+    const res = await fetch(`${WORKERS_URL}${endpoint}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+    if (!res.ok) {
+      const body = await res.text().catch(() => '')
+      console.warn(`[email] ${endpoint} failed (${res.status}):`, body)
+      return { ok: false, status: res.status, detail: body }
+    }
+    return { ok: true }
+  } catch (e) {
+    console.warn(`[email] ${endpoint} network error:`, e.message)
+    return { ok: false, status: 0, detail: e.message }
+  }
 }
 
 // =============================================
@@ -50,22 +72,18 @@ export async function createCase({ studentId, studentName, studentEmail, title, 
   })
 
   // 顧問へ承認依頼メール送信
-  await fetch(`${WORKERS_URL}/send-approval`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      caseId: ref.id,
-      studentName, title, dates, reason,
-      step: 'supervisor',
-      recipientEmail: supervisorEmail,
-      recipientRole: 'supervisor',
-      approveToken,
-      rejectToken,
-      appBaseUrl: APP_BASE,
-    }),
+  const emailResult = await sendEmail('/send-approval', {
+    caseId: ref.id,
+    studentName, title, dates, reason,
+    step: 'supervisor',
+    recipientEmail: supervisorEmail,
+    recipientRole: 'supervisor',
+    approveToken,
+    rejectToken,
+    appBaseUrl: APP_BASE,
   })
 
-  return ref.id
+  return { caseId: ref.id, emailSent: emailResult.ok }
 }
 
 // =============================================
@@ -122,23 +140,19 @@ export async function processToken(token, action) {
           homeRoomRejectToken:  hrRejectToken,
         })
         // 担任へ承認依頼メール
-        await fetch(`${WORKERS_URL}/send-approval`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            caseId,
-            studentName: caseData.studentName,
-            title: caseData.title,
-            dates: caseData.dates,
-            reason: caseData.reason,
-            step: 'homeroom',
-            recipientEmail: caseData.homeRoomEmail,
-            recipientRole: 'homeroom',
-            supervisorEmail: caseData.supervisorEmail,
-            approveToken: hrApproveToken,
-            rejectToken:  hrRejectToken,
-            appBaseUrl: APP_BASE,
-          }),
+        await sendEmail('/send-approval', {
+          caseId,
+          studentName: caseData.studentName,
+          title: caseData.title,
+          dates: caseData.dates,
+          reason: caseData.reason,
+          step: 'homeroom',
+          recipientEmail: caseData.homeRoomEmail,
+          recipientRole: 'homeroom',
+          supervisorEmail: caseData.supervisorEmail,
+          approveToken: hrApproveToken,
+          rejectToken:  hrRejectToken,
+          appBaseUrl: APP_BASE,
         })
         return { ok: true, result: 'supervisor_approved', caseData }
 
@@ -151,16 +165,12 @@ export async function processToken(token, action) {
           homeRoomRejectToken:  '',
         })
         // 生徒へ完了通知メール
-        await fetch(`${WORKERS_URL}/send-complete`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            studentEmail: caseData.studentEmail,
-            studentName:  caseData.studentName,
-            title: caseData.title,
-            dates: caseData.dates,
-            appBaseUrl: APP_BASE,
-          }),
+        await sendEmail('/send-complete', {
+          studentEmail: caseData.studentEmail,
+          studentName:  caseData.studentName,
+          title: caseData.title,
+          dates: caseData.dates,
+          appBaseUrl: APP_BASE,
         })
         return { ok: true, result: 'approved', caseData }
       }
@@ -191,23 +201,19 @@ export async function approveByTeacher(caseId, step, teacherUid) {
       homeRoomApproveToken: hrApproveToken,
       homeRoomRejectToken:  hrRejectToken,
     })
-    await fetch(`${WORKERS_URL}/send-approval`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        caseId,
-        studentName: caseData.studentName,
-        title: caseData.title,
-        dates: caseData.dates,
-        reason: caseData.reason,
-        step: 'homeroom',
-        recipientEmail: caseData.homeRoomEmail,
-        recipientRole: 'homeroom',
-        supervisorEmail: caseData.supervisorEmail,
-        approveToken: hrApproveToken,
-        rejectToken:  hrRejectToken,
-        appBaseUrl: APP_BASE,
-      }),
+    await sendEmail('/send-approval', {
+      caseId,
+      studentName: caseData.studentName,
+      title: caseData.title,
+      dates: caseData.dates,
+      reason: caseData.reason,
+      step: 'homeroom',
+      recipientEmail: caseData.homeRoomEmail,
+      recipientRole: 'homeroom',
+      supervisorEmail: caseData.supervisorEmail,
+      approveToken: hrApproveToken,
+      rejectToken:  hrRejectToken,
+      appBaseUrl: APP_BASE,
     })
   } else {
     await updateDoc(caseRef, {
@@ -217,16 +223,12 @@ export async function approveByTeacher(caseId, step, teacherUid) {
       homeRoomApproveToken: '',
       homeRoomRejectToken:  '',
     })
-    await fetch(`${WORKERS_URL}/send-complete`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        studentEmail: caseData.studentEmail,
-        studentName:  caseData.studentName,
-        title: caseData.title,
-        dates: caseData.dates,
-        appBaseUrl: APP_BASE,
-      }),
+    await sendEmail('/send-complete', {
+      studentEmail: caseData.studentEmail,
+      studentName:  caseData.studentName,
+      title: caseData.title,
+      dates: caseData.dates,
+      appBaseUrl: APP_BASE,
     })
   }
 }
@@ -238,6 +240,36 @@ export async function rejectByTeacher(caseId, step, reason, teacherUid) {
     rejectedReason: reason || '',
     rejectedByUid: teacherUid,
   })
+}
+
+// =============================================
+// ケース削除（生徒がマイページから取り下げ）
+// 顧問承認前（pending_supervisor）のみ許可
+// =============================================
+export async function deleteCaseByStudent(caseId, studentId) {
+  const caseRef  = doc(db, 'cases', caseId)
+  const caseSnap = await getDoc(caseRef)
+  if (!caseSnap.exists()) throw new Error('申請が見つかりません')
+
+  const caseData = caseSnap.data()
+  if (caseData.studentId !== studentId) {
+    throw new Error('この申請を削除する権限がありません')
+  }
+  if (caseData.status !== 'pending_supervisor') {
+    throw new Error('顧問承認後の申請は取り下げできません')
+  }
+
+  await deleteDoc(caseRef)
+}
+
+// =============================================
+// ケース削除（管理者用 — ステータス制限なし）
+// =============================================
+export async function deleteCaseByAdmin(caseId) {
+  const caseRef = doc(db, 'cases', caseId)
+  const caseSnap = await getDoc(caseRef)
+  if (!caseSnap.exists()) throw new Error('ケースが見つかりません')
+  await deleteDoc(caseRef)
 }
 
 // =============================================


### PR DESCRIPTION
## 修正内容

### 1. メール送信エラーハンドリングの改善 (cases.js)
- `sendEmail()` ヘルパー関数を追加し、すべての fetch をラップ
- メール送信失敗（Resend ドメイン未検証の 403 エラー等）でもケース作成は成功させる
- メール送信失敗時にはユーザーに警告メッセージを表示（「顧問の先生に直接ご連絡ください」）
- `createCase()` の返り値を `{ caseId, emailSent }` に変更

### 2. マイページ：申請取り下げ機能 (index.html, cases.js)
- 顧問承認前（`pending_supervisor`）の申請に「申請を取り下げる」ボタンを追加
- `deleteCaseByStudent()` で `studentId` と `status` を検証し、不正な削除を防止

### 3. 管理者ダッシュボード：ケース削除機能 (admin/main.js)
- 全ステータスのケースに「削除」ボタンを追加
- `deleteDoc` で直接 Firestore から削除

## テスト
- [ ] 公欠申請 → メール送信失敗時に警告が表示される（ケースは保存される）
- [ ] マイページ → 顧問承認前の申請に「取り下げ」ボタンが表示され、削除可能
- [ ] マイページ → 顧問承認後の申請には「取り下げ」ボタンが表示されない
- [ ] 管理者ダッシュボード → 全ケースに「削除」ボタンが表示され、削除可能