### PR TITLE
fix: メール送信失敗・ケース削除権限エラーの修正

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,5 @@
+{
+  "firestore": {
+    "rules": "firestore.rules"
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,115 @@
+rules_version = '2';
+
+/**
+ * Firestore Security Rules for mito1-digital-studenthandbook
+ *
+ * IMPORTANT: These rules must be deployed to Firebase Console.
+ *   1. Go to Firebase Console > Firestore Database > Rules
+ *   2. Paste the contents of this file
+ *   3. Click "Publish"
+ *
+ * Alternatively, install firebase-tools and run:
+ *   firebase deploy --only firestore:rules
+ */
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    // =============================================
+    // Helper functions
+    // =============================================
+    function isAuthenticated() {
+      return request.auth != null;
+    }
+
+    function isOwner(userId) {
+      return isAuthenticated() && request.auth.uid == userId;
+    }
+
+    // Check if the user's profile has a specific role
+    // NOTE: This reads from the 'users' collection
+    function getUserRole() {
+      return get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role;
+    }
+
+    function isTeacher() {
+      return isAuthenticated() && getUserRole() == 'teacher';
+    }
+
+    function isStudent() {
+      return isAuthenticated() && getUserRole() == 'student';
+    }
+
+    // =============================================
+    // Users collection
+    // =============================================
+    match /users/{userId} {
+      // Users can read their own profile
+      allow read: if isOwner(userId);
+      // Users can create their own profile during registration
+      allow create: if isOwner(userId);
+      // Users can update their own profile
+      allow update: if isOwner(userId);
+    }
+
+    // =============================================
+    // Cases (absence applications) collection
+    // =============================================
+    match /cases/{caseId} {
+      // Anyone authenticated can read cases
+      // (filtered by query in the app - students see their own, teachers see theirs)
+      allow read: if isAuthenticated();
+
+      // Authenticated users can create cases
+      allow create: if isAuthenticated();
+
+      // Authenticated users can update cases
+      // (approval/rejection by teachers, token updates)
+      allow update: if isAuthenticated();
+
+      // DELETE: Allow authenticated users to delete cases
+      // - Students can delete their own pending cases (checked in app code)
+      // - Teachers/admins can delete any case (checked in app code)
+      allow delete: if isAuthenticated();
+    }
+
+    // =============================================
+    // Content collections (public read, authenticated write)
+    // These are the handbook content collections
+    // =============================================
+    match /content/{docId} {
+      allow read: if true;
+      allow write: if isAuthenticated();
+    }
+
+    // Read-only collections for all users (handbook data)
+    match /{collection}/{docId} {
+      allow read: if collection in [
+        'history', 'principals', 'songs', 'rules', 'special',
+        'events', 'curriculum', 'council-charter', 'council-rules'
+      ];
+      // Write requires authentication (admin panel)
+      allow write: if isAuthenticated() && collection in [
+        'history', 'principals', 'songs', 'rules', 'special',
+        'events', 'curriculum', 'council-charter', 'council-rules'
+      ];
+    }
+
+    // =============================================
+    // Contacts / Inquiries collection
+    // =============================================
+    match /contacts/{contactId} {
+      allow read: if isAuthenticated();
+      allow create: if true;  // Anyone can submit a contact form
+      allow update: if isAuthenticated();
+      allow delete: if isAuthenticated();
+    }
+
+    match /inquiries/{inquiryId} {
+      allow read: if isAuthenticated();
+      allow create: if true;  // Anyone can submit
+      allow update: if isAuthenticated();
+      allow delete: if isAuthenticated();
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -2357,7 +2357,7 @@ window.submitApply = async function() {
         const warn = document.createElement('div')
         warn.className = 'email-warn'
         warn.style.cssText = 'font-size:12px;color:#856404;background:#fff3cd;padding:10px 14px;border-radius:8px;margin-top:12px;text-align:left'
-        warn.innerHTML = '⚠️ 顧問への承認依頼メールの自動送信に失敗しました。<br>申請データは保存済みです。顧問の先生に直接ご連絡ください。'
+        warn.innerHTML = '⚠️ 顧問への承認依頼メールの自動送信に失敗しました。<br>申請データは保存済みです。顧問の先生に直接ご連絡ください。<br><span style="font-size:11px;color:#666;margin-top:4px;display:block">※ Resendの送信元ドメインが未認証の可能性があります。Workers の RESEND_FROM 環境変数を確認してください。</span>'
         document.getElementById('applyDone').querySelector('.card').appendChild(warn)
       }
     }
@@ -2498,7 +2498,12 @@ window.deleteMyCaseBtn = async function(caseId) {
     await deleteCaseByStudent(caseId, _currentUser.uid)
     window.loadMyCases()
   } catch(e) {
-    alert('削除に失敗しました: ' + e.message)
+    const msg = e?.message || String(e)
+    if (msg.includes('Firestore') || msg.includes('permissions')) {
+      alert('削除に失敗しました: Firestoreのセキュリティルールで操作が拒否されました。\nFirebase Console でルールを更新してください。')
+    } else {
+      alert('削除に失敗しました: ' + msg)
+    }
   }
 }
 </script>

--- a/src/admin/main.js
+++ b/src/admin/main.js
@@ -784,9 +784,18 @@ async function saveModal() {
 
 async function deleteItem(col, id) {
   if (!confirm('削除しますか？')) return
-  await deleteDoc(doc(db, col, id))
-  showToast('削除しました')
-  loadSection(currentSection)
+  try {
+    await deleteDoc(doc(db, col, id))
+    showToast('削除しました')
+    loadSection(currentSection)
+  } catch (e) {
+    const msg = e?.message || String(e)
+    if (msg.includes('Missing or insufficient permissions')) {
+      alert('削除に失敗しました: Firestoreのセキュリティルールで操作が拒否されました。\nFirebase Console でルールを更新してください（firestore.rules を参照）。')
+    } else {
+      alert('削除に失敗しました: ' + msg)
+    }
+  }
 }
 
 // =============================================
@@ -984,6 +993,11 @@ window.deleteAdminCase = async function(caseId) {
     showToast('ケースを削除しました')
     loadAdminCases()
   } catch(e) {
-    alert('削除に失敗しました: ' + e.message)
+    const msg = e?.message || String(e)
+    if (msg.includes('Missing or insufficient permissions')) {
+      alert('削除に失敗しました: Firestoreのセキュリティルールで操作が拒否されました。\nFirebase Console > Firestore Database > Rules でルールを更新してください。\n\n詳細: リポジトリの firestore.rules ファイルの内容をコピーして反映してください。')
+    } else {
+      alert('削除に失敗しました: ' + msg)
+    }
   }
 }

--- a/src/cases.js
+++ b/src/cases.js
@@ -12,6 +12,17 @@ const WORKERS_URL = 'https://mito1-hundbook.asanuma-ryuto.workers.dev'
 const APP_BASE    = 'https://ryuto-devs.github.io/mito1-digital-studenthandbook'
 
 // =============================================
+// エラーメッセージのマッピング
+// =============================================
+function friendlyError(e) {
+  const msg = e?.message || String(e)
+  if (msg.includes('Missing or insufficient permissions')) {
+    return 'Firestoreのセキュリティルールで操作が拒否されました。Firebase Console でルールを更新してください（firestore.rules を参照）。'
+  }
+  return msg
+}
+
+// =============================================
 // ランダムトークン生成
 // =============================================
 function genToken() {
@@ -259,7 +270,11 @@ export async function deleteCaseByStudent(caseId, studentId) {
     throw new Error('顧問承認後の申請は取り下げできません')
   }
 
-  await deleteDoc(caseRef)
+  try {
+    await deleteDoc(caseRef)
+  } catch (e) {
+    throw new Error(friendlyError(e))
+  }
 }
 
 // =============================================
@@ -269,7 +284,11 @@ export async function deleteCaseByAdmin(caseId) {
   const caseRef = doc(db, 'cases', caseId)
   const caseSnap = await getDoc(caseRef)
   if (!caseSnap.exists()) throw new Error('ケースが見つかりません')
-  await deleteDoc(caseRef)
+  try {
+    await deleteDoc(caseRef)
+  } catch (e) {
+    throw new Error(friendlyError(e))
+  }
 }
 
 // =============================================

--- a/workers/index.js
+++ b/workers/index.js
@@ -1,0 +1,190 @@
+/**
+ * mito1-hundbook Cloudflare Workers (ES Module)
+ *
+ * wrangler.toml or Cloudflare Dashboard:
+ *   "Module Worker" -> "Module: ES Modules"
+ *
+ * Secrets (Settings > Variables and Secrets):
+ *   GEMINI_API_KEY  -- Gemini API key (Secret)
+ *   RESEND_API_KEY  -- Resend API key (Secret)
+ *   APP_BASE_URL    -- https://ryuto-devs.github.io/mito1-digital-studenthandbook (Plain text)
+ *   RESEND_FROM     -- Verified sender (Plain text, e.g. "mito1-handbook <noreply@yourdomain.com>")
+ *                      If not set, falls back to "mito1-handbook <onboarding@resend.dev>"
+ *                      NOTE: onboarding@resend.dev can ONLY deliver to the Resend account owner's email.
+ *                      To send to any recipient, you MUST verify your own domain in the Resend dashboard
+ *                      and set this variable to an address on that domain.
+ */
+
+const CORS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+}
+
+export default {
+  async fetch(request, env) {
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { headers: CORS })
+    }
+
+    const url = new URL(request.url)
+
+    // GET /approve -> redirect to approve.html
+    if (request.method === 'GET' && url.pathname === '/approve') {
+      const token  = url.searchParams.get('token')
+      const action = url.searchParams.get('action') || 'approve'
+      const base   = env.APP_BASE_URL || 'https://ryuto-devs.github.io/mito1-digital-studenthandbook'
+      if (!token) return new Response('Token is invalid', { status: 400 })
+      return Response.redirect(`${base}/approve.html?token=${encodeURIComponent(token)}&action=${action}`, 302)
+    }
+
+    if (request.method !== 'POST') {
+      return json({ error: 'Method not allowed' }, 405)
+    }
+
+    let body
+    try { body = await request.json() }
+    catch { return json({ error: 'Invalid JSON' }, 400) }
+
+    if (url.pathname === '/send-approval') return sendApproval(body, env)
+    if (url.pathname === '/send-complete')  return sendComplete(body, env)
+
+    // Default -> Gemini proxy
+    return gemini(body, env)
+  }
+}
+
+// -- Gemini proxy -------------------------------------------------------
+async function gemini(body, env) {
+  // Support both GEMINI_KEY and GEMINI_API_KEY for backwards compatibility
+  const apiKey = env.GEMINI_API_KEY || env.GEMINI_KEY
+  if (!apiKey) {
+    return json({ error: { code: 500, message: 'GEMINI_API_KEY not set in Workers secrets' } }, 500)
+  }
+  const res = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${apiKey}`,
+    { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }
+  )
+  const data = await res.json()
+  return json(data, res.status)
+}
+
+// -- Approval request email ---------------------------------------------
+async function sendApproval(body, env) {
+  const {
+    studentName, title, dates, reason,
+    step, recipientEmail, recipientRole,
+    supervisorEmail, approveToken, rejectToken, appBaseUrl,
+  } = body
+
+  // Validate required fields
+  if (!recipientEmail) {
+    return json({ error: 'recipientEmail is required' }, 400)
+  }
+
+  const base     = appBaseUrl || env.APP_BASE_URL || 'https://ryuto-devs.github.io/mito1-digital-studenthandbook'
+  const datesStr = (dates || []).join(', ')
+  const roleName = recipientRole === 'supervisor' ? 'Supervisor' : 'Homeroom Teacher'
+  const approveUrl = `${base}/approve.html?token=${approveToken}&action=approve`
+  const rejectUrl  = `${base}/approve.html?token=${rejectToken}&action=reject`
+  const supNote    = step === 'homeroom'
+    ? `<p style="color:#27ae60;background:#eafaf1;padding:10px 14px;border-radius:6px;font-size:13px;margin:12px 0">Supervisor (${supervisorEmail}) has already approved.</p>`
+    : ''
+
+  const html = `<!DOCTYPE html><html lang="ja"><head><meta charset="UTF-8"></head>
+<body style="font-family:sans-serif;background:#f5f5f5;padding:24px;margin:0">
+<div style="max-width:560px;margin:0 auto;background:#fff;border-radius:12px;overflow:hidden;box-shadow:0 2px 12px rgba(0,0,0,.08)">
+  <div style="background:#1a2744;padding:20px 28px"><div style="color:#fff;font-size:18px;font-weight:700">Mito Daiichi High School</div><div style="color:#a0b0cc;font-size:12px;margin-top:2px">Digital Student Handbook - Absence Application System</div></div>
+  <div style="padding:28px">
+    <p style="color:#333;font-size:15px;margin:0 0 16px">${roleName}<br><br>Please review the following absence application.</p>
+    ${supNote}
+    <table style="width:100%;border-collapse:collapse;font-size:13px;margin:16px 0">
+      <tr style="background:#f8f9fa"><td style="padding:10px 14px;border:1px solid #e0e0e0;font-weight:600;width:30%">Applicant</td><td style="padding:10px 14px;border:1px solid #e0e0e0">${studentName}</td></tr>
+      <tr><td style="padding:10px 14px;border:1px solid #e0e0e0;font-weight:600">Subject</td><td style="padding:10px 14px;border:1px solid #e0e0e0">${title}</td></tr>
+      <tr style="background:#f8f9fa"><td style="padding:10px 14px;border:1px solid #e0e0e0;font-weight:600">Reason</td><td style="padding:10px 14px;border:1px solid #e0e0e0">${reason||'Club activity'}</td></tr>
+      <tr><td style="padding:10px 14px;border:1px solid #e0e0e0;font-weight:600">Absence Dates</td><td style="padding:10px 14px;border:1px solid #e0e0e0">${datesStr}</td></tr>
+    </table>
+    <div style="display:flex;gap:12px;margin-top:24px">
+      <a href="${approveUrl}" style="flex:1;display:block;text-align:center;background:#1a2744;color:#fff;padding:14px;border-radius:8px;text-decoration:none;font-size:14px;font-weight:700">Approve</a>
+      <a href="${rejectUrl}" style="flex:1;display:block;text-align:center;background:#fff;color:#e74c3c;border:1.5px solid #e74c3c;padding:14px;border-radius:8px;text-decoration:none;font-size:14px;font-weight:700">Reject</a>
+    </div>
+    <p style="font-size:11px;color:#999;margin-top:20px">This link is valid for 7 days. You can also manage from the <a href="${base}/teacher.html" style="color:#1a2744">Teacher Dashboard</a>.</p>
+  </div>
+</div></body></html>`
+
+  const r = await resend(env, { to: recipientEmail, subject: `[Absence Application] ${studentName} - ${title} (${datesStr})`, html })
+  if (!r.ok) {
+    const detail = await r.text().catch(() => 'Unknown error')
+    console.error('[send-approval] Resend API error:', r.status, detail)
+    return json({ error: 'Email send failed', detail, status: r.status }, 500)
+  }
+  return json({ ok: true })
+}
+
+// -- Completion notification email --------------------------------------
+async function sendComplete(body, env) {
+  const { studentEmail, studentName, title, dates, appBaseUrl } = body
+
+  if (!studentEmail) {
+    return json({ error: 'studentEmail is required' }, 400)
+  }
+
+  const base     = appBaseUrl || env.APP_BASE_URL || ''
+  const datesStr = (dates || []).join(', ')
+
+  const html = `<!DOCTYPE html><html lang="ja"><head><meta charset="UTF-8"></head>
+<body style="font-family:sans-serif;background:#f5f5f5;padding:24px;margin:0">
+<div style="max-width:560px;margin:0 auto;background:#fff;border-radius:12px;overflow:hidden;box-shadow:0 2px 12px rgba(0,0,0,.08)">
+  <div style="background:#1a2744;padding:20px 28px"><div style="color:#fff;font-size:18px;font-weight:700">Mito Daiichi High School</div><div style="color:#a0b0cc;font-size:12px;margin-top:2px">Digital Student Handbook - Absence Application System</div></div>
+  <div style="padding:28px;text-align:center">
+    <div style="font-size:48px;margin-bottom:12px">&#10004;</div>
+    <div style="font-size:18px;font-weight:700;color:#1a2744;margin-bottom:8px">Absence Application Approved</div>
+    <p style="color:#333;font-size:14px;margin-bottom:16px">${studentName}'s application has been approved by both supervisor and homeroom teacher.</p>
+    <table style="width:100%;border-collapse:collapse;font-size:13px;margin:16px 0;text-align:left">
+      <tr style="background:#f8f9fa"><td style="padding:10px 14px;border:1px solid #e0e0e0;font-weight:600;width:30%">Subject</td><td style="padding:10px 14px;border:1px solid #e0e0e0">${title}</td></tr>
+      <tr><td style="padding:10px 14px;border:1px solid #e0e0e0;font-weight:600">Absence Dates</td><td style="padding:10px 14px;border:1px solid #e0e0e0">${datesStr}</td></tr>
+    </table>
+    <a href="${base}" style="display:inline-block;background:#1a2744;color:#fff;padding:13px 28px;border-radius:8px;text-decoration:none;font-size:14px;font-weight:700;margin-top:8px">Open Handbook</a>
+  </div>
+</div></body></html>`
+
+  const r = await resend(env, { to: studentEmail, subject: `[Approved] Absence Application "${title}" (${datesStr})`, html })
+  if (!r.ok) {
+    const detail = await r.text().catch(() => 'Unknown error')
+    console.error('[send-complete] Resend API error:', r.status, detail)
+    return json({ error: 'Email send failed', detail, status: r.status }, 500)
+  }
+  return json({ ok: true })
+}
+
+// -- Resend API ---------------------------------------------------------
+function resend(env, { to, subject, html }) {
+  if (!env.RESEND_API_KEY) {
+    console.error('[resend] RESEND_API_KEY is not set in Workers secrets')
+    // Return a fake Response-like object that indicates failure
+    return Promise.resolve({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve('RESEND_API_KEY not configured in Workers secrets'),
+    })
+  }
+
+  // Use RESEND_FROM env var if set, otherwise fall back to sandbox address.
+  // IMPORTANT: onboarding@resend.dev can ONLY deliver to the Resend account owner's email.
+  // To send to arbitrary recipients, verify your own domain in Resend and set RESEND_FROM.
+  const from = env.RESEND_FROM || 'mito1-handbook <onboarding@resend.dev>'
+
+  return fetch('https://api.resend.com/emails', {
+    method:  'POST',
+    headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${env.RESEND_API_KEY}` },
+    body:    JSON.stringify({ from, to: [to], subject, html }),
+  })
+}
+
+// -- JSON response helper -----------------------------------------------
+function json(data, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { ...CORS, 'Content-Type': 'application/json' },
+  })
+}


### PR DESCRIPTION
## 問題

### 1. 公欠申請を作成してもメール送信が失敗する
公欠申請を作成すると「顧問への承認依頼メールの自動送信に失敗しました」と表示される。

**原因**: Cloudflare Workers の Resend API で使用している送信元アドレス `onboarding@resend.dev` は、Resendのサンドボックス用アドレスで、**Resendアカウント所有者のメールアドレスにしか送信できない**。任意の宛先に送信するには、Resendで独自ドメインを認証する必要がある。

### 2. ケース削除で権限エラー
マイページ・管理ダッシュボードどちらからケースを削除しようとしても「削除に失敗しました: Missing or insufficient permissions.」と表示される。

**原因**: Firestoreのセキュリティルールで `cases` コレクションの `delete` 操作が許可されていない。

---

## 修正内容

### メール送信の修正
- `workers/index.js` を追加: 改善されたWorkersコード
  - `RESEND_FROM` 環境変数で送信元アドレスを設定可能に
  - `GEMINI_API_KEY` と `GEMINI_KEY` の両方をサポート（後方互換性）
  - `RESEND_API_KEY` 未設定時のエラーハンドリングを追加
  - エラーログの詳細化
- フロントエンドのエラーメッセージにResend設定のヒントを追加

### ケース削除の修正
- `firestore.rules` を追加: 認証済みユーザーに `cases` コレクションのCRUD全操作を許可
- `firebase.json` を追加: ルールファイルの参照設定

### エラーハンドリングの改善
- `src/cases.js`: `friendlyError()` 関数を追加。権限エラー時に分かりやすいメッセージを表示
- `src/admin/main.js`: 削除操作のエラーメッセージを改善
- `index.html`: マイページの申請取り下げエラーメッセージを改善

---

## デプロイ手順

### Firestore ルールの反映（ケース削除の修正に必須）
1. [Firebase Console](https://console.firebase.google.com/) を開く
2. Firestore Database > ルール タブを開く
3. `firestore.rules` の内容をコピー＆ペースト
4. 「公開」をクリック

### Workers の更新（メール送信の修正に必須）
1. Cloudflare ダッシュボードを開く
2. Workers > `mito1-hundbook` のコードを `workers/index.js` の内容に置き換え
3. Settings > Variables and Secrets に以下を追加:
   - `RESEND_FROM`: 認証済みドメインのメールアドレス（例: `mito1-handbook <noreply@yourdomain.com>`）

### Resend ドメイン認証（メール送信の根本修正に必須）
1. [Resend ダッシュボード](https://resend.com/domains) を開く
2. 独自ドメインを追加・認証する（DNS設定が必要）
3. 認証完了後、Workers の `RESEND_FROM` を認証済みドメインのアドレスに設定