### PR TITLE
Fix Vite build error due to syntax error in src/cases.js

### DIFF
--- a/src/cases.js
+++ b/src/cases.js
@@ -215,7 +215,6 @@ export async function processToken(token, action, caseIdFromUrl = null) {
         return { ok: true, result: 'approved', caseData }
       }
     }
-  }
 
   return { ok: false, reason: 'token_not_found' }
 }


### PR DESCRIPTION
Fixed a syntax error in `src/cases.js` where an extra closing brace was present at the end of the `processToken` function. This was causing the `npm run build` command to fail in GitHub Actions. After removing the brace, the build now completes successfully.

---
*PR created automatically by Jules for task [2953584274560679645](https://jules.google.com/task/2953584274560679645) started by @Ryuto-dev*