### PR TITLE
公欠申請の承認エラー修正とUI改善

### DIFF
--- a/src/approve.js
+++ b/src/approve.js
@@ -1,4 +1,4 @@
-import { processToken } from './cases.js'
+import { processToken, getCaseById } from './cases.js'
 
 const params = new URLSearchParams(location.search)
 const caseId = params.get('caseId')
@@ -22,19 +22,51 @@ async function main() {
     return
   }
 
+  // caseId があれば情報を取得して表示
+  let caseData = null
+  if (caseId) {
+    try {
+      caseData = await getCaseById(caseId)
+    } catch (e) {
+      console.warn('Failed to fetch case info:', e)
+    }
+  }
+
   // 確認画面を先に表示（action=approve の場合）
   if (action === 'approve') {
+    let infoHtml = '確認中...'
+    if (caseData) {
+      const datesStr = (caseData.dates || []).join('、')
+      infoHtml = `
+        <div class="info-box" style="margin:16px 0">
+          <div class="info-row"><span class="info-key">申請者</span><span id="caseStudentName"></span></div>
+          <div class="info-row"><span class="info-key">件名</span><span id="caseTitle"></span></div>
+          <div class="info-row"><span class="info-key">公欠日</span><span id="caseDates"></span></div>
+        </div>`
+    } else if (caseId) {
+      infoHtml = '<div style="margin:16px 0;color:var(--enjii)">申請情報が見つかりませんでした</div>'
+    }
+
     card.innerHTML = `
       <div class="icon">📋</div>
       <div class="ttl">公欠申請の承認確認</div>
       <div class="sub">以下の申請を承認してよろしいですか？</div>
-      <div id="caseInfo" style="margin:16px 0;font-size:13px;color:var(--text-3)">確認中...</div>
+      <div id="caseInfo">${infoHtml}</div>
       <button class="btn btn-approve" id="btnApprove">✓ 承認する</button>
-      <button class="btn btn-reject" onclick="location.href=location.href.replace('action=approve','action=reject')">差し戻す</button>
+      <button class="btn btn-reject" id="btnReject">差し戻す</button>
     `
+    if (caseData) {
+      document.getElementById('caseStudentName').textContent = caseData.studentName
+      document.getElementById('caseTitle').textContent = caseData.title
+      document.getElementById('caseDates').textContent = (caseData.dates || []).join('、')
+    }
+
     document.getElementById('btnApprove').onclick = doProcess
-    // トークンからケース情報を取得して表示（processはまだしない）
-    // ここでは情報表示のみ、実際の処理はボタンクリックで行う
+    document.getElementById('btnReject').onclick = () => {
+      const url = new URL(location.href)
+      url.searchParams.set('action', 'reject')
+      location.href = url.toString()
+    }
   } else {
     // reject は確認なしで処理
     doProcess()
@@ -60,22 +92,33 @@ async function doProcess() {
     }
 
     const d = result.caseData
-    const datesStr = (d.dates || []).join('、')
+    const infoBoxId = 'infoBox_' + Date.now()
     const infoBox = `
-      <div class="info-box">
-        <div class="info-row"><span class="info-key">申請者</span><span>${d.studentName}</span></div>
-        <div class="info-row"><span class="info-key">件名</span><span>${d.title}</span></div>
-        <div class="info-row"><span class="info-key">公欠日</span><span>${datesStr}</span></div>
+      <div class="info-box" id="${infoBoxId}">
+        <div class="info-row"><span class="info-key">申請者</span><span class="val-name"></span></div>
+        <div class="info-row"><span class="info-key">件名</span><span class="val-title"></span></div>
+        <div class="info-row"><span class="info-key">公欠日</span><span class="val-dates"></span></div>
       </div>`
 
     if (result.result === 'rejected') {
       render('🔴', '申請を差し戻しました', '生徒に通知されます。', infoBox)
+      const box = document.getElementById(infoBoxId)
+      box.querySelector('.val-name').textContent = d.studentName
+      box.querySelector('.val-title').textContent = d.title
+      box.querySelector('.val-dates').textContent = (d.dates || []).join('、')
     } else if (result.result === 'supervisor_approved') {
       render('✅', '顧問承認が完了しました',
         '担任の先生に承認依頼メールを送信しました。', infoBox)
     } else if (result.result === 'approved') {
       render('🎉', '公欠申請が承認されました',
         '顧問・担任の両方の承認が完了し、<br>生徒に完了通知を送信しました。', infoBox)
+    }
+
+    const box = document.getElementById(infoBoxId)
+    if (box) {
+      box.querySelector('.val-name').textContent = d.studentName
+      box.querySelector('.val-title').textContent = d.title
+      box.querySelector('.val-dates').textContent = (d.dates || []).join('、')
     }
   } catch(e) {
     render('❌', 'エラーが発生しました', e.message)

--- a/src/cases.js
+++ b/src/cases.js
@@ -101,6 +101,19 @@ export async function createCase({ studentId, studentName, studentEmail, title, 
 // =============================================
 // トークンで承認・差し戻し処理
 // =============================================
+// =============================================
+// IDで単一ケース取得（承認画面用）
+// =============================================
+export async function getCaseById(caseId) {
+  const docRef = doc(db, 'cases', caseId)
+  const snap = await getDoc(docRef)
+  if (!snap.exists()) return null
+  return { id: snap.id, ...snap.data() }
+}
+
+// =============================================
+// トークンで承認・差し戻し処理
+// =============================================
 export async function processToken(token, action, caseIdFromUrl = null) {
   // 顧問トークン or 担任トークンを検索
   const fields = [

--- a/workers/index.js
+++ b/workers/index.js
@@ -31,11 +31,16 @@ export default {
 
     // GET /approve -> redirect to approve.html
     if (request.method === 'GET' && url.pathname === '/approve') {
+      const caseId = url.searchParams.get('caseId')
       const token  = url.searchParams.get('token')
       const action = url.searchParams.get('action') || 'approve'
       const base   = env.APP_BASE_URL || 'https://ryuto-devs.github.io/mito1-digital-studenthandbook'
       if (!token) return new Response('Token is invalid', { status: 400 })
-      return Response.redirect(`${base}/approve.html?token=${encodeURIComponent(token)}&action=${action}`, 302)
+
+      let redirectUrl = `${base}/approve.html?token=${encodeURIComponent(token)}&action=${action}`
+      if (caseId) redirectUrl += `&caseId=${encodeURIComponent(caseId)}`
+
+      return Response.redirect(redirectUrl, 302)
     }
 
     if (request.method !== 'POST') {


### PR DESCRIPTION
公欠申請の承認プロセスで発生していた「Missing or insufficient permissions」エラーを修正しました。

主な変更点：
1. **Cloudflare Workerの修正**: `/approve` エンドポイントからのリダイレクト時に `caseId` パラメータが欠落していたため、これを保持するように修正しました。これにより、フロントエンドがクエリ（要：認証）ではなく直接のドキュメント取得（要：公開アクセス）を行えるようになります。
2. **`src/approve.js` の機能強化**: 承認ボタンを押す前に、申請者名・件名・日付を表示するようにしました。また、XSS対策として `textContent` を使用するように改善しました。
3. **`src/cases.js` へのヘルパー追加**: IDから直接ケースを取得する `getCaseById` 関数を追加しました。

Firestoreのルールについては、現在の `firestore.rules` のままでも動作するはずですが、もし引き続き問題が発生する場合は、直接お伝えした修正案の適用をご検討ください。

---
*PR created automatically by Jules for task [2301673476232284396](https://jules.google.com/task/2301673476232284396) started by @Ryuto-dev*