### PR TITLE
fix(firestore): メール承認リンクの Missing or insufficient permissions エラーを修正

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -56,15 +56,18 @@ service cloud.firestore {
     // Cases (absence applications) collection
     // =============================================
     match /cases/{caseId} {
-      // Helper function to check if the update request provides a valid token
-      function isValidTokenUpdate() {
-        let providedToken = request.resource.data.providedToken;
-        return providedToken != null && (
-          providedToken == resource.data.approveToken ||
-          providedToken == resource.data.rejectToken ||
-          providedToken == resource.data.homeRoomApproveToken ||
-          providedToken == resource.data.homeRoomRejectToken
-        );
+      // Helper: check if the update request provides a valid token
+      // (used for unauthenticated email one-click approval/rejection)
+      function hasValidToken() {
+        return 'providedToken' in request.resource.data
+          && request.resource.data.providedToken is string
+          && request.resource.data.providedToken.size() > 0
+          && (
+               request.resource.data.providedToken == resource.data.approveToken
+            || request.resource.data.providedToken == resource.data.rejectToken
+            || request.resource.data.providedToken == resource.data.homeRoomApproveToken
+            || request.resource.data.providedToken == resource.data.homeRoomRejectToken
+          );
       }
 
       // Allow individual document read (get) for token-based lookup
@@ -76,9 +79,11 @@ service cloud.firestore {
       allow create: if isAuthenticated();
 
       // Allow update if:
-      // 1. User is authenticated (teacher dashboard approval)
+      // 1. User is authenticated (teacher dashboard approval), OR
       // 2. Request provides a valid token (email one-click approval)
-      allow update: if isAuthenticated() || isValidTokenUpdate();
+      //    — the token in the request body must match one of the
+      //      tokens stored on the existing document.
+      allow update: if isAuthenticated() || hasValidToken();
 
       // DELETE: Only authenticated users can delete cases (student withdrawal)
       allow delete: if isAuthenticated();


### PR DESCRIPTION
## 問題
先生がメールの承認リンクから approve.html を開き「承認する」ボタンを押すと、
**❌ エラーが発生しました Missing or insufficient permissions.** と表示されて承認できない。

## 原因
メールリンクから開いた approve.html では先生は Firebase Auth に未ログインの状態。
Firestore セキュリティルールの `isValidTokenUpdate()` 関数で `let` 変数を使って
`request.resource.data.providedToken` を取得する方式に、未認証リクエスト時のルール評価で
問題が発生していた。

## 修正内容
`isValidTokenUpdate()` を `hasValidToken()` に書き換え：
- `'providedToken' in request.resource.data` で明示的にフィールド存在チェック
- `is string` による型チェック
- `.size() > 0` による空文字チェック
- 4つのトークンフィールド（approveToken, rejectToken, homeRoomApproveToken, homeRoomRejectToken）との比較
- `let` 変数のスコーピング問題を回避

## デプロイ手順
Firebase Console > Firestore Database > Rules で更新後の `firestore.rules` の内容をペーストして Publish するか、
`firebase deploy --only firestore:rules` を実行してください。

## テスト
1. 公欠申請を提出
2. 顧問先生のメールで承認リンクをクリック
3. approve.html で「承認する」ボタンをクリック
4. エラーが出ず、正しく承認されることを確認