### PR TITLE
fix(approval): 承認ワークフロー・先生用ダッシュボード修正

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -26,20 +26,6 @@ service cloud.firestore {
       return isAuthenticated() && request.auth.uid == userId;
     }
 
-    // Check if the user's profile has a specific role
-    // NOTE: This reads from the 'users' collection
-    function getUserRole() {
-      return get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role;
-    }
-
-    function isTeacher() {
-      return isAuthenticated() && getUserRole() == 'teacher';
-    }
-
-    function isStudent() {
-      return isAuthenticated() && getUserRole() == 'student';
-    }
-
     // =============================================
     // Users collection
     // =============================================

--- a/src/approve.js
+++ b/src/approve.js
@@ -1,7 +1,9 @@
-import { processToken, getCaseById } from './cases.js'
+import { processToken, getCaseById, findCaseIdByToken } from './cases.js'
+import { auth } from './firebase.js'
+import { onAuthStateChanged } from 'firebase/auth'
 
 const params = new URLSearchParams(location.search)
-const caseId = params.get('caseId')
+let caseId = params.get('caseId')
 const token  = params.get('token')
 const action = params.get('action') || 'approve'
 
@@ -22,28 +24,55 @@ async function main() {
     return
   }
 
+  // caseId が URL になくても、ログイン中ならクエリで探す
+  if (!caseId) {
+    // まずログイン状態を確認
+    const user = await new Promise(resolve => {
+      const unsub = onAuthStateChanged(auth, u => { unsub(); resolve(u) })
+    })
+    if (user) {
+      // ログイン中 → list 権限でトークン検索可能
+      try {
+        caseId = await findCaseIdByToken(token)
+        if (caseId) {
+          // URL に caseId を追加してリロード（次回以降のためにも）
+          const url = new URL(location.href)
+          url.searchParams.set('caseId', caseId)
+          history.replaceState(null, '', url.toString())
+        }
+      } catch (e) {
+        console.warn('Failed to find caseId by token:', e)
+      }
+    }
+  }
+
+  if (!caseId) {
+    // caseId が取得できなかった場合 — ログインして再試行を促す
+    render('❌', 'リンクの形式が古い可能性があります',
+      'この承認リンクにはケースIDが含まれていません。<br>' +
+      '<a href="/mito1-digital-studenthandbook/teacher.html" style="color:#1a2744;font-weight:600">先生用ダッシュボード</a>からログインして承認してください。')
+    return
+  }
+
   // caseId があれば情報を取得して表示
   let caseData = null
-  if (caseId) {
-    try {
-      caseData = await getCaseById(caseId)
-    } catch (e) {
-      console.warn('Failed to fetch case info:', e)
-    }
+  try {
+    caseData = await getCaseById(caseId)
+  } catch (e) {
+    console.warn('Failed to fetch case info:', e)
   }
 
   // 確認画面を先に表示（action=approve の場合）
   if (action === 'approve') {
-    let infoHtml = '確認中...'
+    let infoHtml = ''
     if (caseData) {
-      const datesStr = (caseData.dates || []).join('、')
       infoHtml = `
         <div class="info-box" style="margin:16px 0">
           <div class="info-row"><span class="info-key">申請者</span><span id="caseStudentName"></span></div>
           <div class="info-row"><span class="info-key">件名</span><span id="caseTitle"></span></div>
           <div class="info-row"><span class="info-key">公欠日</span><span id="caseDates"></span></div>
         </div>`
-    } else if (caseId) {
+    } else {
       infoHtml = '<div style="margin:16px 0;color:var(--enjii)">申請情報が見つかりませんでした</div>'
     }
 
@@ -76,6 +105,8 @@ async function main() {
 async function doProcess() {
   const btn = document.getElementById('btnApprove')
   if (btn) { btn.disabled = true; btn.textContent = '処理中...' }
+  const rejectBtn = document.getElementById('btnReject')
+  if (rejectBtn) { rejectBtn.disabled = true }
 
   try {
     const result = await processToken(token, action, caseId)
@@ -102,10 +133,6 @@ async function doProcess() {
 
     if (result.result === 'rejected') {
       render('🔴', '申請を差し戻しました', '生徒に通知されます。', infoBox)
-      const box = document.getElementById(infoBoxId)
-      box.querySelector('.val-name').textContent = d.studentName
-      box.querySelector('.val-title').textContent = d.title
-      box.querySelector('.val-dates').textContent = (d.dates || []).join('、')
     } else if (result.result === 'supervisor_approved') {
       render('✅', '顧問承認が完了しました',
         '担任の先生に承認依頼メールを送信しました。', infoBox)

--- a/src/cases.js
+++ b/src/cases.js
@@ -102,6 +102,20 @@ export async function createCase({ studentId, studentName, studentEmail, title, 
 // トークンで承認・差し戻し処理
 // =============================================
 // =============================================
+// トークンからcaseIdを検索（認証済みユーザー用）
+// list権限が必要なため、ログイン中のみ使用可
+// =============================================
+export async function findCaseIdByToken(token) {
+  const tokenFields = ['approveToken', 'rejectToken', 'homeRoomApproveToken', 'homeRoomRejectToken']
+  for (const field of tokenFields) {
+    const q = query(collection(db, 'cases'), where(field, '==', token))
+    const snap = await getDocs(q)
+    if (!snap.empty) return snap.docs[0].id
+  }
+  return null
+}
+
+// =============================================
 // IDで単一ケース取得（承認画面用）
 // =============================================
 export async function getCaseById(caseId) {
@@ -126,7 +140,7 @@ export async function processToken(token, action, caseIdFromUrl = null) {
   let caseDoc, caseId, caseData, step, act
 
   if (caseIdFromUrl) {
-    // caseIdがある場合は直接取得（セキュリティ的に望ましい）
+    // caseIdがある場合は直接取得（get は認証不要）
     const docRef = doc(db, 'cases', caseIdFromUrl)
     const snap = await getDoc(docRef)
     if (!snap.exists()) return { ok: false, reason: 'token_not_found' }
@@ -140,19 +154,9 @@ export async function processToken(token, action, caseIdFromUrl = null) {
     step = match.step
     act = match.act
   } else {
-    // 互換性のためのクエリ検索
-    for (const f of fields) {
-      const q = query(collection(db, 'cases'), where(f.field, '==', token))
-      const snap = await getDocs(q)
-      if (snap.empty) continue
-
-      caseDoc  = snap.docs[0]
-      caseId   = caseDoc.id
-      caseData = caseDoc.data()
-      step = f.step
-      act = f.act
-      break
-    }
+    // caseId がない場合 — リスト権限不要の方法でトークン照合は不可能
+    // エラーメッセージで caseId 付きリンクの使用を促す
+    return { ok: false, reason: 'token_not_found' }
   }
 
   if (!caseDoc) return { ok: false, reason: 'token_not_found' }
@@ -349,9 +353,11 @@ export async function getMyCases(studentId) {
 // 先生の担当ケース一覧（自分のメール宛）
 // =============================================
 export async function getTeacherCases(teacherEmail) {
+  // composite index 不要: where のみでクエリし、JS側でソート
+  // （orderBy + where の組み合わせは Firestore composite index が必要なため）
   const [asSupervisor, asHomeRoom] = await Promise.all([
-    getDocs(query(collection(db, 'cases'), where('supervisorEmail', '==', teacherEmail), orderBy('createdAt', 'desc'))),
-    getDocs(query(collection(db, 'cases'), where('homeRoomEmail',   '==', teacherEmail), orderBy('createdAt', 'desc'))),
+    getDocs(query(collection(db, 'cases'), where('supervisorEmail', '==', teacherEmail))),
+    getDocs(query(collection(db, 'cases'), where('homeRoomEmail',   '==', teacherEmail))),
   ])
   const map = new Map()
   ;[...asSupervisor.docs, ...asHomeRoom.docs].forEach(d => map.set(d.id, { id: d.id, ...d.data() }))

--- a/src/teacher_page.js
+++ b/src/teacher_page.js
@@ -1,3 +1,4 @@
+import { auth } from './firebase.js'
 import { onAuth, getCurrentProfile, logout } from './auth.js'
 import { getTeacherCases, approveByTeacher, rejectByTeacher } from './cases.js'
 
@@ -14,17 +15,43 @@ let myProfile = null
 
 onAuth(async user => {
   if (!user) { location.href = '/mito1-digital-studenthandbook/auth.html'; return }
-  myProfile = await getCurrentProfile()
-  if (!myProfile) { location.href = '/mito1-digital-studenthandbook/auth.html'; return }
-  document.getElementById('headerName').textContent = `${myProfile.name} 先生`
-  await loadCases()
+  try {
+    myProfile = await getCurrentProfile(user)
+    if (!myProfile) {
+      // users ドキュメントが無い場合、auth 情報から最低限のプロフィールを構築
+      myProfile = { uid: user.uid, email: user.email, name: user.email, role: 'teacher' }
+    }
+    document.getElementById('headerName').textContent = `${myProfile.name} 先生`
+    await loadCases()
+  } catch (e) {
+    console.error('Teacher page init error:', e)
+    document.getElementById('caseList').innerHTML =
+      `<div class="empty">読み込みに失敗しました: ${e.message}<br><br><button onclick="location.reload()" style="padding:8px 16px;cursor:pointer">再読み込み</button></div>`
+  }
 })
 
 async function loadCases() {
   document.getElementById('caseList').innerHTML =
     '<div class="loading-wrap"><span class="spinner"></span>読み込み中...</div>'
-  allCases = await getTeacherCases(myProfile.email)
-  renderCases()
+  try {
+    // auth.currentUser.email と profile.email の両方で検索
+    const authEmail = auth.currentUser?.email
+    const profileEmail = myProfile.email
+    // メインのメールアドレスで取得
+    allCases = await getTeacherCases(profileEmail)
+    // auth メールが異なる場合は追加検索してマージ
+    if (authEmail && authEmail !== profileEmail) {
+      const extra = await getTeacherCases(authEmail)
+      const ids = new Set(allCases.map(c => c.id))
+      extra.forEach(c => { if (!ids.has(c.id)) allCases.push(c) })
+      allCases.sort((a, b) => (b.createdAt?.seconds || 0) - (a.createdAt?.seconds || 0))
+    }
+    renderCases()
+  } catch (e) {
+    console.error('loadCases error:', e)
+    document.getElementById('caseList').innerHTML =
+      `<div class="empty">申請の読み込みに失敗しました: ${e.message}<br><br><button onclick="location.reload()" style="padding:8px 16px;cursor:pointer">再読み込み</button></div>`
+  }
 }
 
 function renderCases() {
@@ -40,7 +67,9 @@ function renderCases() {
 
   el.innerHTML = filtered.map(c => {
     const datesStr = (c.dates || []).join('、')
-    const isSupervisor = c.supervisorEmail === myProfile.email
+    const authEmail = auth.currentUser?.email
+    const isSupervisor = c.supervisorEmail === myProfile.email || c.supervisorEmail === authEmail
+    const isHomeRoom = c.homeRoomEmail === myProfile.email || c.homeRoomEmail === authEmail
     const myRole  = isSupervisor ? '顧問' : '担任'
     const canApprove =
       (isSupervisor && c.status === 'pending_supervisor') ||


### PR DESCRIPTION
## 修正内容

### 1. approve.html「Missing or insufficient permissions」エラーの修正
- **原因**: メールリンクに `caseId` パラメータが含まれていない場合、`processToken()` が `getDocs()`（リスト操作）を使用していたが、Firestore ルールで `list` 操作は認証が必要。承認ページは未認証でアクセスされるため失敗していた。
- **対策**: `processToken()` は `caseId` を使った `getDoc()`（個別取得、認証不要）のみを使用するよう変更。古いリンク（caseId なし）に対しては、ログイン中なら `findCaseIdByToken()` でフォールバック検索を実行。未ログインの場合は先生用ダッシュボードへの案内メッセージを表示。

### 2. 先生用ダッシュボード無限ローディングの修正
- **原因**: `getTeacherCases()` が `where` + `orderBy` の複合クエリを使用していたが、Firestore にコンポジットインデックスが未作成のためクエリが失敗。エラーハンドリングがなくローディング表示のまま停止していた。
- **対策**: Firestore クエリから `orderBy` を削除（`where` のみのクエリはインデックス不要）。ソートは JavaScript 側で実行。エラー時はメッセージと再読み込みボタンを表示。プロフィール取得失敗時は auth 情報から最低限のプロフィールを構築（リダイレクトループ防止）。先生のメールアドレスマッチングを auth メールとプロフィールメールの両方で実施。

### 3. Firestore ルールのクリーンアップ
- 未使用の `getUserRole()`、`isTeacher()`、`isStudent()` ヘルパー関数を削除（不要なドキュメント読み取りの削減）。
- コアルールは変更なし: get=公開、list=認証必須、update=認証 or トークン。

### 重要: Firestore ルールのデプロイが必要
変更後の `firestore.rules` を Firebase Console にデプロイしてください:
1. Firebase Console > Firestore Database > Rules
2. `firestore.rules` の内容を貼り付け
3. 「Publish」をクリック