### PR TITLE
feat: 画像表示・AI検索改善・承認フロー修正・特別教育活動/憲章対応

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -549,12 +549,17 @@ button,input,textarea,select{font-family:'Noto Sans JP',sans-serif}
         <div class="adm-section-header">
           <div>
             <div class="adm-section-title">特別教育活動</div>
-            <div class="adm-section-sub">条文を管理</div>
+            <div class="adm-section-sub">説明文と条文を管理</div>
           </div>
           <button class="btn-add" data-add="special">
             <svg viewBox="0 0 24 24"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
             条文を追加
           </button>
+        </div>
+        <div class="item-card" style="padding:20px 22px;margin-bottom:16px">
+          <div style="font-size:13px;font-weight:600;color:var(--text);margin-bottom:8px">条文の前の説明文（目的など）</div>
+          <div style="font-size:11px;color:var(--text-3);margin-bottom:8px">改行を含む説明文を入力できます。条文の前に表示されます。</div>
+          <div id="specialDescForm"><div class="loading-spinner"><div class="spinner"></div>読み込み中...</div></div>
         </div>
         <div id="specialList"><div class="loading-spinner"><div class="spinner"></div>読み込み中...</div></div>
       </section>
@@ -607,12 +612,17 @@ button,input,textarea,select{font-family:'Noto Sans JP',sans-serif}
         <div class="adm-section-header">
           <div>
             <div class="adm-section-title">知道生徒会憲章</div>
-            <div class="adm-section-sub">条文を管理</div>
+            <div class="adm-section-sub">前文・総則・細則の条文を管理</div>
           </div>
           <button class="btn-add" data-add="council-charter">
             <svg viewBox="0 0 24 24"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
             条文を追加
           </button>
+        </div>
+        <div class="item-card" style="padding:20px 22px;margin-bottom:16px">
+          <div style="font-size:13px;font-weight:600;color:var(--text);margin-bottom:8px">前文</div>
+          <div style="font-size:11px;color:var(--text-3);margin-bottom:8px">憲章の前文を入力できます。条文の前に表示されます。</div>
+          <div id="charterPreambleForm"><div class="loading-spinner"><div class="spinner"></div>読み込み中...</div></div>
         </div>
         <div id="councilCharterList"><div class="loading-spinner"><div class="spinner"></div>読み込み中...</div></div>
       </section>

--- a/index.html
+++ b/index.html
@@ -110,33 +110,14 @@ a{text-decoration:none;color:inherit}
   position:relative;z-index:1;
 }
 
-/* SVGの校章リング — strokeが伸びる */
-.load-crest-svg{
+/* 校章画像 */
+.load-crest-img{
   width:80px;height:80px;margin-bottom:28px;
+  object-fit:contain;
+  filter:brightness(0) invert(1);
   animation:crestAppear .6s ease .1s both;
 }
 @keyframes crestAppear{from{opacity:0;transform:scale(.85)}to{opacity:1;transform:scale(1)}}
-
-.load-crest-ring{
-  stroke:rgba(255,255,255,.7);stroke-width:1.5;fill:none;
-  stroke-dasharray:226;stroke-dashoffset:226;
-  animation:drawRing 1.1s cubic-bezier(.4,0,.2,1) .2s forwards;
-  transform-origin:center;transform:rotate(-90deg);
-}
-@keyframes drawRing{to{stroke-dashoffset:0}}
-
-.load-crest-inner{
-  stroke:rgba(139,26,44,.7);stroke-width:1;fill:none;
-  stroke-dasharray:163;stroke-dashoffset:163;
-  animation:drawRing 0.9s cubic-bezier(.4,0,.2,1) .55s forwards;
-  transform-origin:center;transform:rotate(-90deg);
-}
-.load-crest-text{
-  font-family:'Noto Serif JP',serif;font-size:11px;font-weight:700;
-  fill:rgba(255,255,255,.85);text-anchor:middle;dominant-baseline:middle;
-  opacity:0;animation:ftextIn .4s ease .9s forwards;
-}
-@keyframes ftextIn{to{opacity:1}}
 
 /* 学校名 — 縦書き風スタック */
 .load-school-wrap{
@@ -238,10 +219,8 @@ a{text-decoration:none;color:inherit}
   cursor:pointer;flex-shrink:0;
 }
 .brand-crest{
-  width:31px;height:31px;background:var(--navy);border-radius:50%;
-  display:flex;align-items:center;justify-content:center;
-  font-family:'Noto Serif JP',serif;font-size:11px;font-weight:700;
-  color:white;letter-spacing:.03em;flex-shrink:0;
+  width:31px;height:31px;border-radius:50%;flex-shrink:0;
+  object-fit:contain;
 }
 .brand-names{display:flex;flex-direction:column}
 .brand-main{
@@ -467,7 +446,7 @@ a{text-decoration:none;color:inherit}
 /* ===========================
    HOME PAGE
 =========================== */
-.home-wrap{max-width:900px;margin:0 auto;padding:52px 0 20px}
+.home-wrap{max-width:900px;margin:0 auto;padding:80px 0 20px}
 
 .home-brand{text-align:center;margin-bottom:44px}
 .home-book{
@@ -483,11 +462,10 @@ a{text-decoration:none;color:inherit}
 .home-book::before{content:'';position:absolute;inset:0;background:linear-gradient(135deg,rgba(255,255,255,.04) 0%,transparent 55%)}
 @keyframes homeFloat{0%,100%{transform:translateY(0) rotate(-1deg)}50%{transform:translateY(-6px) rotate(-.5deg)}}
 .hb-crest{
-  width:38px;height:38px;border:1.5px solid rgba(255,255,255,.82);border-radius:50%;
-  display:flex;align-items:center;justify-content:center;
-  font-family:'Noto Serif JP',serif;font-size:9px;font-weight:700;
-  color:rgba(255,255,255,.92);background:rgba(255,255,255,.06);
-  letter-spacing:.04em;position:relative;z-index:1;
+  width:38px;height:38px;border-radius:50%;
+  object-fit:contain;
+  filter:brightness(0) invert(1);
+  position:relative;z-index:1;
 }
 .hb-ttl{
   font-family:'Noto Serif JP',serif;font-size:9.5px;font-weight:600;
@@ -938,7 +916,7 @@ tr:last-child td{border-bottom:none}
   .ai-float{bottom:calc(var(--bn-h) + var(--safe-b) + 10px)}
   /* ヘッダーの下にコンテンツが隠れないよう明示的に余白確保 */
   .pg-header{scroll-margin-top:calc(var(--header-h) + 16px)}
-  .home-wrap{padding-top:32px}
+  .home-wrap{padding-top:48px}
 }
 @media(max-width:500px){
   .cat-grid{
@@ -953,7 +931,7 @@ tr:last-child td{border-bottom:none}
   .cat-card-about .cat-card-line { margin-bottom:8px; }
   .cat-card{min-height:100px}
   .song-verses{grid-template-columns:1fr}
-  .home-wrap{padding:36px 0 10px}
+  .home-wrap{padding:48px 0 10px}
 }
 @media(display-mode:standalone){
   .sidebar{display:none!important}
@@ -999,15 +977,8 @@ select.cf-input{cursor:pointer}
 <!-- LOADING -->
 <div id="loading">
   <div class="load-stage">
-    <!-- 校章SVG - strokeが描かれる -->
-    <svg class="load-crest-svg" viewBox="0 0 80 80">
-      <!-- 外円 -->
-      <circle class="load-crest-ring" cx="40" cy="40" r="36"/>
-      <!-- 内円 -->
-      <circle class="load-crest-inner" cx="40" cy="40" r="26"/>
-      <!-- 文字 -->
-      <text class="load-crest-text" x="40" y="40">校章</text>
-    </svg>
+    <!-- 校章画像 -->
+    <img class="load-crest-img" src="/mito1-digital-studenthandbook/crest.png" alt="校章">
 
     <!-- 学校名 -->
     <div class="load-school-wrap">
@@ -1034,7 +1005,7 @@ select.cf-input{cursor:pointer}
   </button>
 
   <div class="header-brand" onclick="nav('home')">
-    <div class="brand-crest">校章</div>
+    <img class="brand-crest" src="/mito1-digital-studenthandbook/crest.png" alt="校章">
     <div class="brand-names">
       <span class="brand-main">デジタル生徒手帳</span>
       <span class="brand-sub">水戸第一高等学校</span>
@@ -1269,7 +1240,7 @@ select.cf-input{cursor:pointer}
     <div class="home-wrap">
       <div class="home-brand">
         <div class="home-book">
-          <div class="hb-crest">校章</div>
+          <img class="hb-crest" src="/mito1-digital-studenthandbook/crest.png" alt="校章">
           <div class="hb-ttl">生徒手帳</div>
           <div class="hb-div"></div>
           <div class="hb-school">茨城県立<br>水戸第一高等学校</div>
@@ -1995,31 +1966,34 @@ function runSearchPage(q){
    
    【プロンプト構成】
    1. システム指示（役割・回答形式）
-   2. 全条文タイトル一覧（_aiContext: ページ読み込み時に1回キャッシュ）
-   3. 質問にヒットした条文の本文（doSearchで上位5件 → snipを付加）
+   2. 全条文データ（_aiContext: ページ読み込み時にキャッシュした全文テキスト）
+   3. 質問にヒットした条文のスニペット（doSearchで上位8件）
    4. ユーザーの質問
-   ※ 毎回全文を送らず、ヒット分のみ付加してAPIコストを最小化
 ================================= */
 // NOTE: "hundbook" might be a typo for "handbook". Please verify against the Worker deployment.
 const AI_WORKERS_URL = 'https://mito1-hundbook.asanuma-ryuto.workers.dev';
 window._aiContext = '';
 
 async function callGemini(q){
-  // 検索ヒットした条文の本文を取得（最大5件）
-  const hits = doSearch(q).slice(0,5)
+  // 検索ヒットした条文の本文を取得（最大8件）
+  const hits = doSearch(q).slice(0,8)
     .map(r=>`■${r.path}「${r.title}」\n${r.snip}`)
     .join('\n\n');
 
+  // 全条文データ（_aiContext に全文をキャッシュ済み）
+  const fullContext = window._aiContext || '（読み込み中）';
+
   const prompt =
 `あなたは茨城県立水戸第一高等学校デジタル生徒手帳のAIアシスタントです。
-以下の手帳データをもとに、在校生の質問に丁寧・簡潔な日本語で答えてください（200字以内目安）。
+以下の手帳の全データをもとに、在校生の質問に丁寧・正確な日本語で答えてください。
 データにない内容は「手帳に記載がないため確認できません」と答えてください。
+回答は簡潔にまとめ、該当する条文番号があれば明記してください。
 
-【手帳の目次（全セクション）】
-${window._aiContext || '（読み込み中）'}
+【手帳の全データ】
+${fullContext}
 
-【質問に関連する条文・データ】
-${hits || '（該当条文なし）'}
+【質問に特に関連するデータ】
+${hits || '（該当なし）'}
 
 【質問】
 ${q}`;

--- a/src/admin/main.js
+++ b/src/admin/main.js
@@ -65,6 +65,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     if (btn.dataset.saveAction === 'goals') saveGoals()
     if (btn.dataset.saveAction === 'council-activities') saveCouncilActivities()
+    if (btn.dataset.saveAction === 'special-desc') saveSpecialDesc()
+    if (btn.dataset.saveAction === 'charter-preamble') saveCharterPreamble()
   })
 })
 
@@ -128,11 +130,11 @@ async function loadSection(sec) {
     case 'goals':            return loadGoalsForm()
     case 'songs':            return loadList('songs', renderSongsList)
     case 'rules':            return loadList('rules', renderArticleList('rulesList'))
-    case 'special':          return loadList('special', renderArticleList('specialList'))
+    case 'special':          return Promise.all([loadList('special', renderArticleList('specialList')), loadSpecialDescForm()])
     case 'curriculum':       return loadList('curriculum', renderCurriculumList)
     case 'events':           return loadList('events', renderEventsList)
     case 'council-activities': return loadCouncilActivitiesForm()
-    case 'council-charter':  return loadList('council-charter', renderArticleList('councilCharterList'))
+    case 'council-charter':  return Promise.all([loadList('council-charter', renderArticleList('councilCharterList')), loadCharterPreambleForm()])
     case 'council-rules':    return loadList('council-rules', renderArticleList('councilRulesList'))
     case 'inquiries':        return loadInquiries()
     case 'cases':            return loadAdminCases()
@@ -301,6 +303,14 @@ function renderSongsList(items) {
 // ARTICLES (rules / special / charter / council-rules)
 // =============================================
 function renderArticleList(containerId) {
+  // Map container ID to Firestore collection name
+  const colMap = {
+    rulesList: 'rules',
+    specialList: 'special',
+    councilCharterList: 'council-charter',
+    councilRulesList: 'council-rules',
+  }
+  const colName = colMap[containerId] || containerId.replace('List', '')
   return function(items) {
     const el = document.getElementById(containerId)
     if (!items.length) { el.innerHTML = emptyState(); return }
@@ -309,11 +319,12 @@ function renderArticleList(containerId) {
         <div class="item-card-header">
           <span class="item-num">${item.number || ''}</span>
           <span class="item-title">${item.title || ''}</span>
+          ${item.section ? `<span style="font-size:10px;color:var(--navy);background:rgba(26,39,68,.07);padding:2px 7px;border-radius:4px;margin-left:4px">${item.section}</span>` : ''}
           <div class="item-actions">
-            <button class="btn-icon" data-edit="${containerId.replace('List','')}|${item.id}">
+            <button class="btn-icon" data-edit="${colName}|${item.id}">
               <svg viewBox="0 0 24 24"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
             </button>
-            <button class="btn-icon del" data-delete="${containerId.replace('List','')}|${item.id}">
+            <button class="btn-icon del" data-delete="${colName}|${item.id}">
               <svg viewBox="0 0 24 24"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/></svg>
             </button>
           </div>
@@ -447,6 +458,51 @@ async function saveCouncilActivities() {
   // 後方互換のため overview に保存、committees は空にする
   await setDoc(doc(db, 'content', 'council-activities'), { overview: content, committees: '' })
   showToast('生徒会活動を保存しました')
+}
+
+// =============================================
+// 特別教育活動 説明文（content/special ドキュメント）
+// =============================================
+async function loadSpecialDescForm() {
+  const el = document.getElementById('specialDescForm')
+  if (!el) return
+  const snap = await getDoc(doc(db, 'content', 'special')).catch(() => null)
+  const data = snap?.data() || {}
+  el.innerHTML = `
+    <textarea id="specialDescription" rows="6" style="width:100%;font-size:13px;border:1.5px solid var(--border);border-radius:var(--r);padding:9px 12px;line-height:1.7;resize:vertical" placeholder="特別教育活動の目的や概要を入力...">${data.description || ''}</textarea>
+    <button class="btn-save" style="margin-top:8px" data-save-action="special-desc">保存</button>
+  `
+}
+
+async function saveSpecialDesc() {
+  const description = document.getElementById('specialDescription').value.trim()
+  // merge with existing data
+  const snap = await getDoc(doc(db, 'content', 'special')).catch(() => null)
+  const existing = snap?.data() || {}
+  await setDoc(doc(db, 'content', 'special'), { ...existing, description })
+  showToast('特別教育活動の説明文を保存しました')
+}
+
+// =============================================
+// 知道生徒会憲章 前文（content/council-charter ドキュメント）
+// =============================================
+async function loadCharterPreambleForm() {
+  const el = document.getElementById('charterPreambleForm')
+  if (!el) return
+  const snap = await getDoc(doc(db, 'content', 'council-charter')).catch(() => null)
+  const data = snap?.data() || {}
+  el.innerHTML = `
+    <textarea id="charterPreamble" rows="6" style="width:100%;font-size:13px;border:1.5px solid var(--border);border-radius:var(--r);padding:9px 12px;line-height:1.7;resize:vertical" placeholder="憲章の前文を入力...">${data.preamble || ''}</textarea>
+    <button class="btn-save" style="margin-top:8px" data-save-action="charter-preamble">保存</button>
+  `
+}
+
+async function saveCharterPreamble() {
+  const preamble = document.getElementById('charterPreamble').value.trim()
+  const snap = await getDoc(doc(db, 'content', 'council-charter')).catch(() => null)
+  const existing = snap?.data() || {}
+  await setDoc(doc(db, 'content', 'council-charter'), { ...existing, preamble })
+  showToast('憲章の前文を保存しました')
 }
 
 // =============================================
@@ -686,6 +742,13 @@ const articleForm = (type) => ({
         <input type="text" id="f_title_art" placeholder="目的">
       </div>
     </div>
+    ${type === 'council-charter' ? `
+    <div class="form-row">
+      <label>セクション（任意 — 例: 総則、細則）</label>
+      <input type="text" id="f_section" placeholder="総則">
+      <div style="font-size:10.5px;color:var(--text-3);margin-top:3px">条文が「総則」「細則」などのセクションに分かれる場合に指定</div>
+    </div>
+    ` : ''}
     <div class="form-row">
       <label>章見出し（任意 — 例: 第一章 総則）</label>
       <input type="text" id="f_chapter" placeholder="第一章 総則">
@@ -703,14 +766,19 @@ const articleForm = (type) => ({
       <input type="number" id="f_order" value="0">
     </div>
   `,
-  getData: () => ({
-    number:  document.getElementById('f_number').value.trim(),
-    title:   document.getElementById('f_title_art').value.trim(),
-    chapter: document.getElementById('f_chapter').value.trim(),
-    body:    document.getElementById('f_body').value.trim(),
-    items:   document.getElementById('f_items').value.trim().split('\n').filter(Boolean),
-    order:   Number(document.getElementById('f_order').value),
-  }),
+  getData: () => {
+    const data = {
+      number:  document.getElementById('f_number').value.trim(),
+      title:   document.getElementById('f_title_art').value.trim(),
+      chapter: document.getElementById('f_chapter').value.trim(),
+      body:    document.getElementById('f_body').value.trim(),
+      items:   document.getElementById('f_items').value.trim().split('\n').filter(Boolean),
+      order:   Number(document.getElementById('f_order').value),
+    }
+    const sectionEl = document.getElementById('f_section')
+    if (sectionEl) data.section = sectionEl.value.trim()
+    return data
+  },
   fill: (data) => {
     document.getElementById('f_number').value    = data.number  || ''
     document.getElementById('f_title_art').value = data.title   || ''
@@ -718,6 +786,8 @@ const articleForm = (type) => ({
     document.getElementById('f_body').value      = data.body    || ''
     document.getElementById('f_items').value     = (data.items || []).join('\n')
     document.getElementById('f_order').value     = data.order   ?? 0
+    const sectionEl = document.getElementById('f_section')
+    if (sectionEl) sectionEl.value = data.section || ''
   }
 })
 

--- a/src/approve.js
+++ b/src/approve.js
@@ -24,18 +24,35 @@ async function main() {
     return
   }
 
-  // caseId が URL になくても、ログイン中ならクエリで探す
+  // caseId が URL にない場合、Workers API でトークンから検索を試みる
   if (!caseId) {
-    // まずログイン状態を確認
+    try {
+      const workerUrl = 'https://mito1-hundbook.asanuma-ryuto.workers.dev'
+      const res = await fetch(`${workerUrl}/resolve-token?token=${encodeURIComponent(token)}`)
+      if (res.ok) {
+        const data = await res.json()
+        if (data.caseId) {
+          caseId = data.caseId
+          // URL に caseId を追加
+          const url = new URL(location.href)
+          url.searchParams.set('caseId', caseId)
+          history.replaceState(null, '', url.toString())
+        }
+      }
+    } catch (e) {
+      console.warn('Worker resolve-token failed, trying auth fallback:', e)
+    }
+  }
+
+  // それでもなければログイン状態でFirestore直接検索
+  if (!caseId) {
     const user = await new Promise(resolve => {
       const unsub = onAuthStateChanged(auth, u => { unsub(); resolve(u) })
     })
     if (user) {
-      // ログイン中 → list 権限でトークン検索可能
       try {
         caseId = await findCaseIdByToken(token)
         if (caseId) {
-          // URL に caseId を追加してリロード（次回以降のためにも）
           const url = new URL(location.href)
           url.searchParams.set('caseId', caseId)
           history.replaceState(null, '', url.toString())
@@ -47,9 +64,8 @@ async function main() {
   }
 
   if (!caseId) {
-    // caseId が取得できなかった場合 — ログインして再試行を促す
-    render('❌', 'リンクの形式が古い可能性があります',
-      'この承認リンクにはケースIDが含まれていません。<br>' +
+    render('❌', 'ケースIDを特定できません',
+      'このリンクからケースを特定できませんでした。<br>' +
       '<a href="/mito1-digital-studenthandbook/teacher.html" style="color:#1a2744;font-weight:600">先生用ダッシュボード</a>からログインして承認してください。')
     return
   }
@@ -73,7 +89,7 @@ async function main() {
           <div class="info-row"><span class="info-key">公欠日</span><span id="caseDates"></span></div>
         </div>`
     } else {
-      infoHtml = '<div style="margin:16px 0;color:var(--enjii)">申請情報が見つかりませんでした</div>'
+      infoHtml = '<div style="margin:16px 0;color:var(--enjii)">申請情報の詳細が取得できませんでしたが、承認処理は可能です。</div>'
     }
 
     card.innerHTML = `
@@ -83,6 +99,11 @@ async function main() {
       <div id="caseInfo">${infoHtml}</div>
       <button class="btn btn-approve" id="btnApprove">✓ 承認する</button>
       <button class="btn btn-reject" id="btnReject">差し戻す</button>
+      <div id="rejectReasonWrap" style="display:none;margin-top:12px">
+        <textarea id="rejectReasonInput" placeholder="差し戻し理由（任意）" rows="3"
+          style="width:100%;border:1.5px solid #e2e2de;border-radius:8px;padding:10px 12px;font-size:13px;font-family:inherit;resize:vertical;margin-bottom:8px"></textarea>
+        <button class="btn btn-reject" id="btnRejectConfirm">差し戻しを確定する</button>
+      </div>
     `
     if (caseData) {
       document.getElementById('caseStudentName').textContent = caseData.studentName
@@ -90,34 +111,59 @@ async function main() {
       document.getElementById('caseDates').textContent = (caseData.dates || []).join('、')
     }
 
-    document.getElementById('btnApprove').onclick = doProcess
+    document.getElementById('btnApprove').onclick = () => doProcess('approve')
     document.getElementById('btnReject').onclick = () => {
+      document.getElementById('rejectReasonWrap').style.display = ''
+      document.getElementById('btnReject').style.display = 'none'
+    }
+    document.getElementById('btnRejectConfirm').onclick = () => doProcess('reject')
+  } else if (action === 'reject') {
+    // reject 確認画面
+    let infoHtml = ''
+    if (caseData) {
+      infoHtml = `
+        <div class="info-box" style="margin:16px 0">
+          <div class="info-row"><span class="info-key">申請者</span><span>${caseData.studentName || ''}</span></div>
+          <div class="info-row"><span class="info-key">件名</span><span>${caseData.title || ''}</span></div>
+          <div class="info-row"><span class="info-key">公欠日</span><span>${(caseData.dates || []).join('、')}</span></div>
+        </div>`
+    }
+    card.innerHTML = `
+      <div class="icon">⚠️</div>
+      <div class="ttl">申請を差し戻しますか？</div>
+      <div class="sub">この操作は取り消せません。</div>
+      ${infoHtml}
+      <textarea id="rejectReasonInput" placeholder="差し戻し理由（任意）" rows="3"
+        style="width:100%;border:1.5px solid #e2e2de;border-radius:8px;padding:10px 12px;font-size:13px;font-family:inherit;resize:vertical;margin-bottom:12px"></textarea>
+      <button class="btn btn-reject" id="btnRejectConfirm">差し戻す</button>
+      <button class="btn btn-back" id="btnCancel" style="margin-top:4px">キャンセル</button>
+    `
+    document.getElementById('btnRejectConfirm').onclick = () => doProcess('reject')
+    document.getElementById('btnCancel').onclick = () => {
       const url = new URL(location.href)
-      url.searchParams.set('action', 'reject')
+      url.searchParams.set('action', 'approve')
       location.href = url.toString()
     }
-  } else {
-    // reject は確認なしで処理
-    doProcess()
   }
 }
 
-async function doProcess() {
-  const btn = document.getElementById('btnApprove')
+async function doProcess(processAction) {
+  const btn = document.getElementById('btnApprove') || document.getElementById('btnRejectConfirm')
   if (btn) { btn.disabled = true; btn.textContent = '処理中...' }
   const rejectBtn = document.getElementById('btnReject')
   if (rejectBtn) { rejectBtn.disabled = true }
 
   try {
-    const result = await processToken(token, action, caseId)
+    const result = await processToken(token, processAction, caseId)
 
     if (!result.ok) {
       if (result.reason === 'already_processed') {
         render('⚠️', 'すでに処理済みです',
           'この申請はすでに処理されています。<br>ダッシュボードで最新の状況をご確認ください。',
-          `<a class="btn btn-back" style="display:block;margin-top:16px;text-decoration:none;padding:13px;border-radius:10px" href="/mito1-digital-studenthandbook/auth.html">ダッシュボードへ</a>`)
+          `<a class="btn btn-back" style="display:block;margin-top:16px;text-decoration:none;padding:13px;border-radius:10px" href="/mito1-digital-studenthandbook/teacher.html">ダッシュボードへ</a>`)
       } else {
-        render('❌', 'リンクが無効です', 'このリンクは有効期限切れか、すでに使用されています。')
+        render('❌', 'リンクが無効です', 'このリンクは有効期限切れか、すでに使用されています。<br>' +
+          '<a href="/mito1-digital-studenthandbook/teacher.html" style="color:#1a2744;font-weight:600">先生用ダッシュボード</a>から操作してください。')
       }
       return
     }

--- a/src/main.js
+++ b/src/main.js
@@ -122,17 +122,43 @@ async function loadSongs() {
 
 // =============================================
 // 条文（諸規定・特別教育活動・生徒会憲章・生徒会関係諸規定）
+// description（説明文/前文）やsection（総則/細則）にも対応
 // =============================================
-function renderArticles(items, containerId, tocId) {
+function renderArticles(items, containerId, tocId, options = {}) {
   const el  = document.getElementById(containerId)
   const toc = document.getElementById(tocId)
-  if (!el || !items.length) return
+  if (!el) return
 
   let html     = ''
   let tocHtml  = ''
   let prevChapter = ''
+  let prevSection = ''
+
+  // description（説明文/前文）がある場合はページ冒頭に表示
+  if (options.description) {
+    html += `<div class="card" style="margin-bottom:18px">
+      <div class="card-body" style="font-size:14px;color:var(--text-2);line-height:2.0;white-space:pre-wrap">${options.description}</div>
+    </div>`
+    tocHtml += `<a class="toc-lnk sub" style="font-style:italic;color:var(--text-3)">説明・前文</a>`
+  }
+
+  // preamble（前文テキスト — 憲章用）
+  if (options.preamble) {
+    html += `<div class="card" style="margin-bottom:18px">
+      <div class="card-h2">前文</div>
+      <div class="card-body" style="font-size:14px;color:var(--text-2);line-height:2.0;white-space:pre-wrap">${options.preamble}</div>
+    </div>`
+    tocHtml += `<a class="toc-lnk sub" style="font-weight:600">前文</a>`
+  }
 
   items.forEach(item => {
+    // セクション見出し（総則/細則）
+    if (item.section && item.section !== prevSection) {
+      html += `<div class="chapter-div" style="background:rgba(139,26,44,.06);border-left-color:var(--enjii);font-size:15px;margin-top:28px">${item.section}</div>`
+      tocHtml += `<a class="toc-lnk sub" style="font-weight:700;color:var(--enjii)">${item.section}</a>`
+      prevSection = item.section
+    }
+
     // 章見出し
     if (item.chapter && item.chapter !== prevChapter) {
       html += `<div class="chapter-div">${item.chapter}</div>`
@@ -177,8 +203,17 @@ function renderArticles(items, containerId, tocId) {
 
 async function loadArticles(col, containerId, tocId) {
   const items = await fetchOrdered(col)
-  if (!items.length) return
-  renderArticles(items, containerId, tocId)
+
+  // コンテンツドキュメントから description / preamble を取得
+  const contentDoc = await fetchDoc('content', col)
+  const options = {}
+  if (contentDoc) {
+    if (contentDoc.description) options.description = contentDoc.description
+    if (contentDoc.preamble) options.preamble = contentDoc.preamble
+  }
+
+  if (!items.length && !options.description && !options.preamble) return
+  renderArticles(items, containerId, tocId, options)
 
   const label = `全${items.length}条`
 
@@ -344,40 +379,64 @@ async function loadCouncilActivities() {
 
 // =============================================
 // 検索インデックスをFirestoreから動的生成
+// 全条文・説明文・前文を完全に格納
 // =============================================
 async function buildSearchIndex() {
-  const [rules, special, events, history, charter, councilRules] = await Promise.all([
+  const [rules, special, events, history, charter, councilRules, songs, goals] = await Promise.all([
     fetchOrdered('rules'),
     fetchOrdered('special'),
     fetchOrdered('events'),
     fetchOrdered('history'),
     fetchOrdered('council-charter'),
     fetchOrdered('council-rules'),
+    fetchOrdered('songs'),
+    fetchDoc('content', 'goals'),
+  ])
+
+  // コンテンツドキュメント（description/preamble）を取得
+  const [specialContent, charterContent, councilRulesContent, councilActivitiesContent] = await Promise.all([
+    fetchDoc('content', 'special'),
+    fetchDoc('content', 'council-charter'),
+    fetchDoc('content', 'council-rules'),
+    fetchDoc('content', 'council-activities'),
   ])
 
   const index = []
 
   rules.forEach(item => {
+    const fullText = [item.body || '', ...(item.items || [])].join(' ')
     index.push({
       path: `諸規定 › ${item.number}`,
       title: item.title || item.number,
-      snip: (item.body || '') + ' ' + (item.items || []).join(' '),
+      snip: fullText,
       page: 'rules',
-      id: `rulesList-${item.id}`,
-      tags: item.title || '',
+      id: `rulesContentFront-${item.id}`,
+      tags: [item.title || '', item.chapter || ''].join(' '),
     })
   })
 
   special.forEach(item => {
+    const fullText = [item.body || '', ...(item.items || [])].join(' ')
     index.push({
       path: `特別教育活動 › ${item.number}`,
       title: item.title || item.number,
-      snip: (item.body || '') + ' ' + (item.items || []).join(' '),
+      snip: fullText,
       page: 'special',
-      id: `specialList-${item.id}`,
-      tags: item.title || '',
+      id: `specialContentFront-${item.id}`,
+      tags: [item.title || '', item.chapter || ''].join(' '),
     })
   })
+
+  // 特別教育活動の説明文
+  if (specialContent?.description) {
+    index.push({
+      path: '特別教育活動 › 説明',
+      title: '特別教育活動について',
+      snip: specialContent.description,
+      page: 'special',
+      tags: '特別教育活動 目的 説明',
+    })
+  }
 
   events.forEach(item => {
     index.push({
@@ -400,37 +459,78 @@ async function buildSearchIndex() {
   })
 
   charter.forEach(item => {
+    const fullText = [item.body || '', ...(item.items || [])].join(' ')
     index.push({
       path: `知道生徒会憲章 › ${item.number}`,
       title: item.title || item.number,
-      snip: item.body || '',
+      snip: fullText,
       page: 'council-charter',
-      id: `councilCharterList-${item.id}`,
-      tags: item.title || '',
+      id: `charterContentFront-${item.id}`,
+      tags: [item.title || '', item.chapter || '', item.section || ''].join(' '),
     })
   })
 
+  // 憲章の前文
+  if (charterContent?.preamble) {
+    index.push({
+      path: '知道生徒会憲章 › 前文',
+      title: '知道生徒会憲章 前文',
+      snip: charterContent.preamble,
+      page: 'council-charter',
+      tags: '憲章 前文',
+    })
+  }
+
   councilRules.forEach(item => {
+    const fullText = [item.body || '', ...(item.items || [])].join(' ')
     index.push({
       path: `生徒会関係諸規定 › ${item.number}`,
       title: item.title || item.number,
-      snip: item.body || '',
+      snip: fullText,
       page: 'council-rules',
-      id: `councilRulesList-${item.id}`,
-      tags: item.title || '',
+      id: `councilRulesContentFront-${item.id}`,
+      tags: [item.title || '', item.chapter || ''].join(' '),
     })
   })
+
+  // 歌詞
+  songs.forEach(item => {
+    index.push({
+      path: `歌詞 › ${item.type || ''}`,
+      title: item.title || item.type || '',
+      snip: (item.verses || []).join('\n'),
+      page: 'songs',
+      tags: '歌詞 校歌 応援歌',
+    })
+  })
+
+  // 就学の目標
+  if (goals?.text) {
+    index.push({
+      path: '就学の目標',
+      title: '就学の目標',
+      snip: goals.text,
+      page: 'goals',
+      tags: '就学 目標 校是',
+    })
+  }
+
+  // 生徒会活動
+  if (councilActivitiesContent?.overview) {
+    index.push({
+      path: '生徒会活動',
+      title: '生徒会活動',
+      snip: councilActivitiesContent.overview,
+      page: 'council-activities',
+      tags: '生徒会 活動',
+    })
+  }
 
   // グローバルの検索インデックスを動的データで更新
   window.DYNAMIC_SEARCH_INDEX = index
 
-  // AIコンテキスト：条文の要約を compact にキャッシュ（全文はAPIコール時に検索ヒット分のみ付加）
-  const ctxLines = []
-  rules.forEach(r    => ctxLines.push(`[諸規定 ${r.number}]${r.title}：${(r.body||'').slice(0,80)}`))
-  special.forEach(r  => ctxLines.push(`[特別活動 ${r.number}]${r.title}：${(r.body||'').slice(0,60)}`))
-  charter.forEach(r  => ctxLines.push(`[憲章 ${r.number}]${r.title}：${(r.body||'').slice(0,60)}`))
-  councilRules.forEach(r => ctxLines.push(`[会規定 ${r.number}]${r.title}：${(r.body||'').slice(0,60)}`))
-  window._aiContext = ctxLines.join('\n')
+  // 全データをキャッシュ（AI用）
+  window._allArticleData = { rules, special, charter, councilRules, specialContent, charterContent, councilRulesContent }
 }
 
 // =============================================
@@ -451,33 +551,81 @@ export async function loadAllData() {
     loadArticles('council-rules',   'councilRulesContentFront', 'councilRulesTocFront'),
     buildSearchIndex(),
   ])
-  // AIコンテキスト生成（Firestoreデータの圧縮サマリー）
+  // AIコンテキスト生成（Firestoreデータの完全サマリー）
   buildAIContext()
 }
 
 // =============================================
 // AIコンテキスト生成
-// タイトル+本文冒頭をセクションごとにキャッシュ
-// 質問時にdoSearch()のヒット条文本文を追加付加
+// 全条文の完全なテキストをAIに送れるようにキャッシュ
 // =============================================
 function buildAIContext() {
   if (!window.DYNAMIC_SEARCH_INDEX || !window.DYNAMIC_SEARCH_INDEX.length) return
 
-  const idx = window.DYNAMIC_SEARCH_INDEX
-  const bySection = {}
-  idx.forEach(item => {
-    const section = item.path.split(' › ')[0]
-    if (!bySection[section]) bySection[section] = []
-    // タイトルと本文冒頭50文字をペアで保持
-    const title = item.title || ''
-    const snip  = (item.snip || '').slice(0, 50)
-    bySection[section].push(snip ? `${title}（${snip}）` : title)
-  })
+  const data = window._allArticleData || {}
 
-  window._aiContext = Object.entries(bySection).map(([sec, entries]) => {
-    const uniq = [...new Set(entries)].slice(0, 12)
-    return `▼${sec}\n${uniq.map(e=>`  ・${e}`).join('\n')}`
-  }).join('\n\n')
+  const lines = []
+
+  // 諸規定（全文）
+  if (data.rules?.length) {
+    lines.push('========== 諸規定（本則） ==========')
+    data.rules.forEach(r => {
+      let text = `${r.number}`
+      if (r.title) text += `（${r.title}）`
+      if (r.chapter) text += ` [${r.chapter}]`
+      if (r.body) text += `\n${r.body}`
+      if (r.items?.length) text += '\n' + r.items.map((it, i) => `  ${i + 1}. ${it}`).join('\n')
+      lines.push(text)
+    })
+  }
+
+  // 特別教育活動（説明文＋全文）
+  if (data.specialContent?.description || data.special?.length) {
+    lines.push('\n========== 特別教育活動 ==========')
+    if (data.specialContent?.description) {
+      lines.push('[説明文]\n' + data.specialContent.description)
+    }
+    data.special?.forEach(r => {
+      let text = `${r.number}`
+      if (r.title) text += `（${r.title}）`
+      if (r.chapter) text += ` [${r.chapter}]`
+      if (r.body) text += `\n${r.body}`
+      if (r.items?.length) text += '\n' + r.items.map((it, i) => `  ${i + 1}. ${it}`).join('\n')
+      lines.push(text)
+    })
+  }
+
+  // 知道生徒会憲章（前文＋全文）
+  if (data.charterContent?.preamble || data.charter?.length) {
+    lines.push('\n========== 知道生徒会憲章 ==========')
+    if (data.charterContent?.preamble) {
+      lines.push('[前文]\n' + data.charterContent.preamble)
+    }
+    data.charter?.forEach(r => {
+      let text = `${r.number}`
+      if (r.title) text += `（${r.title}）`
+      if (r.section) text += ` {${r.section}}`
+      if (r.chapter) text += ` [${r.chapter}]`
+      if (r.body) text += `\n${r.body}`
+      if (r.items?.length) text += '\n' + r.items.map((it, i) => `  ${i + 1}. ${it}`).join('\n')
+      lines.push(text)
+    })
+  }
+
+  // 生徒会関係諸規定（全文）
+  if (data.councilRules?.length) {
+    lines.push('\n========== 生徒会関係諸規定 ==========')
+    data.councilRules.forEach(r => {
+      let text = `${r.number}`
+      if (r.title) text += `（${r.title}）`
+      if (r.chapter) text += ` [${r.chapter}]`
+      if (r.body) text += `\n${r.body}`
+      if (r.items?.length) text += '\n' + r.items.map((it, i) => `  ${i + 1}. ${it}`).join('\n')
+      lines.push(text)
+    })
+  }
+
+  window._aiContext = lines.join('\n')
 }
 
 // =============================================

--- a/workers/index.js
+++ b/workers/index.js
@@ -13,6 +13,8 @@
  *                      NOTE: onboarding@resend.dev can ONLY deliver to the Resend account owner's email.
  *                      To send to any recipient, you MUST verify your own domain in the Resend dashboard
  *                      and set this variable to an address on that domain.
+ *   FIREBASE_PROJECT_ID -- Firebase project ID (Plain text, e.g. "mito1-digital-handbook")
+ *   FIREBASE_API_KEY    -- Firebase Web API Key (Plain text, for Firestore REST API)
  */
 
 const CORS = {
@@ -43,6 +45,11 @@ export default {
       return Response.redirect(redirectUrl, 302)
     }
 
+    // GET /resolve-token?token=xxx -> resolve token to caseId via Firestore REST API
+    if (request.method === 'GET' && url.pathname === '/resolve-token') {
+      return resolveToken(url.searchParams.get('token'), env)
+    }
+
     if (request.method !== 'POST') {
       return json({ error: 'Method not allowed' }, 405)
     }
@@ -57,6 +64,57 @@ export default {
     // Default -> Gemini proxy
     return gemini(body, env)
   }
+}
+
+// -- Resolve token to caseId via Firestore REST API -------------------------
+async function resolveToken(token, env) {
+  if (!token) return json({ error: 'token required' }, 400)
+
+  const projectId = env.FIREBASE_PROJECT_ID
+  if (!projectId) {
+    return json({ error: 'FIREBASE_PROJECT_ID not set' }, 500)
+  }
+
+  const tokenFields = ['approveToken', 'rejectToken', 'homeRoomApproveToken', 'homeRoomRejectToken']
+
+  for (const field of tokenFields) {
+    try {
+      const firestoreUrl = `https://firestore.googleapis.com/v1/projects/${projectId}/databases/(default)/documents:runQuery`
+      const queryBody = {
+        structuredQuery: {
+          from: [{ collectionId: 'cases' }],
+          where: {
+            fieldFilter: {
+              field: { fieldPath: field },
+              op: 'EQUAL',
+              value: { stringValue: token }
+            }
+          },
+          limit: 1
+        }
+      }
+
+      const res = await fetch(firestoreUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(queryBody)
+      })
+
+      if (res.ok) {
+        const results = await res.json()
+        if (results && results.length > 0 && results[0].document) {
+          // Extract document ID from the name path
+          const docName = results[0].document.name
+          const caseId = docName.split('/').pop()
+          return json({ caseId, field })
+        }
+      }
+    } catch (e) {
+      console.error(`[resolve-token] Error querying field ${field}:`, e)
+    }
+  }
+
+  return json({ error: 'token not found' }, 404)
 }
 
 // -- Gemini proxy -------------------------------------------------------
@@ -90,6 +148,7 @@ async function sendApproval(body, env) {
   const base     = appBaseUrl || env.APP_BASE_URL || 'https://ryuto-devs.github.io/mito1-digital-studenthandbook'
   const datesStr = (dates || []).join(', ')
   const roleName = recipientRole === 'supervisor' ? 'Supervisor' : 'Homeroom Teacher'
+  // Always include caseId in approve/reject URLs
   const approveUrl = `${base}/approve.html?caseId=${body.caseId}&token=${approveToken}&action=approve`
   const rejectUrl  = `${base}/approve.html?caseId=${body.caseId}&token=${rejectToken}&action=reject`
   const supNote    = step === 'homeroom'
@@ -177,7 +236,11 @@ function resend(env, { to, subject, html }) {
   // Use RESEND_FROM env var if set, otherwise fall back to sandbox address.
   // IMPORTANT: onboarding@resend.dev can ONLY deliver to the Resend account owner's email.
   if (!env.RESEND_FROM) {
-    return new Response('RESEND_FROM is not set. onboarding@resend.dev can only send to the Resend account owner. Please verify your domain and set the RESEND_FROM environment variable.', { status: 403 })
+    return Promise.resolve({
+      ok: false,
+      status: 403,
+      text: () => Promise.resolve('RESEND_FROM is not set. onboarding@resend.dev can only send to the Resend account owner. Please verify your domain and set the RESEND_FROM environment variable.'),
+    })
   }
 
   const from = env.RESEND_FROM


### PR DESCRIPTION
## 変更内容

### 1. 画像表示の対応
- ローディング画面: SVGテキスト校章 → 実際のcrest.png画像（反転フィルター付き）
- ホーム画面上部の手帳: テキスト「校章」→ crest.png画像
- ヘッダー左上の校章: テキスト「校章」→ crest.png画像

### 2. UIレイアウト修正
- `.home-wrap`の上paddingを52pxから80pxに変更

### 3. AI検索の改善
- 全条文の**完全なテキスト**をAIに送信するように変更（以前は50～80文字に切り詰めていた）
- `buildAIContext()`が全条文の本文・項・説明文・前文を含む完全なテキストを生成
- 検索インデックスに歌詞・就学の目標・生徒会活動なども含めるように拡張
- AIプロンプトを改善し、条文番号を明記するように指示

### 4. 公欠申請承認フローの修正
- **ワンタイムURLからの承認が機能しない問題を修正**
- Cloudflare Workerに`/resolve-token`エンドポイントを追加
- Firestore REST APIでトークンからcaseIdを逆引き
- approve.jsがWorker API → 認証フォールバックの順で試行
- 差し戻し時の理由入力UIを追加

### 5. 特別教育活動ページの対応
- 条文の前に説明文（目的など、改行あり）を表示する機能を追加
- Firestoreの`content/special`ドキュメントの`description`フィールドを使用
- 管理画面に説明文エディタを追加
- 検索インデックスとAIコンテキストに説明文を含む

### 6. 知道生徒会憲章の対応
- 前文の表示に対応（`content/council-charter`ドキュメントの`preamble`フィールド）
- 条文に「セクション」フィールドを追加（総則・細則の区分け）
- セクション見出しを条文リスト内に表示
- 管理画面に前文エディタとセクションフィールドを追加

### 7. 管理画面の改善
- 条文フォームにセクションフィールドを追加（知道生徒会憲章用）
- 特別教育活動・憲章に説明文/前文エディタを追加
- コンテナID→コレクション名のマッピングを修正

### Worker環境変数（新規追加が必要）
承認フローのトークン解決機能を使うには:
- `FIREBASE_PROJECT_ID`: FirebaseプロジェクトID