### PR TITLE
feat: 多数の改善・修正を一括実装

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -449,6 +449,11 @@ button,input,textarea,select{font-family:'Noto Sans JP',sans-serif}
         公欠申請ケース
         <span id="casesBadge" style="display:none;background:#856404;color:#fff;border-radius:10px;font-size:10px;padding:1px 6px;margin-left:auto"></span>
       </button>
+      <div class="sb-section-label">ユーザー管理</div>
+      <button class="adm-sb-item" data-sec="users">
+        <svg viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+        ユーザー一覧
+      </button>
     </aside>
 
     <!-- MAIN -->
@@ -679,6 +684,42 @@ button,input,textarea,select{font-family:'Noto Sans JP',sans-serif}
           </div>
         </div>
         <div id="adminCasesList"><div class="loading-spinner"><div class="spinner"></div>読み込み中...</div></div>
+      </section>
+
+      <!-- USERS -->
+      <section class="adm-section" id="sec-users">
+        <div class="adm-section-header">
+          <div>
+            <div class="adm-section-title">ユーザー管理</div>
+            <div class="adm-section-sub">登録ユーザーの閲覧・編集・削除</div>
+          </div>
+        </div>
+        <div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:16px;align-items:center">
+          <select style="font-size:12px;padding:6px 10px;border-radius:7px;border:1px solid var(--border);background:var(--surface);color:var(--text)" onchange="filterUsers('role',this.value)">
+            <option value="all">すべてのロール</option>
+            <option value="student">生徒のみ</option>
+            <option value="teacher">先生のみ</option>
+            <option value="admin">管理者のみ</option>
+          </select>
+          <select style="font-size:12px;padding:6px 10px;border-radius:7px;border:1px solid var(--border);background:var(--surface);color:var(--text)" onchange="filterUsers('grade',this.value)">
+            <option value="all">全学年</option>
+            <option value="1">1年</option>
+            <option value="2">2年</option>
+            <option value="3">3年</option>
+          </select>
+          <select style="font-size:12px;padding:6px 10px;border-radius:7px;border:1px solid var(--border);background:var(--surface);color:var(--text)" onchange="filterUsers('class',this.value)">
+            <option value="all">全クラス</option>
+            <option value="1">1組</option>
+            <option value="2">2組</option>
+            <option value="3">3組</option>
+            <option value="4">4組</option>
+            <option value="5">5組</option>
+            <option value="6">6組</option>
+          </select>
+          <input type="text" placeholder="名前・メールで検索..." oninput="searchUsers(this.value)"
+            style="font-size:12px;padding:6px 10px;border-radius:7px;border:1px solid var(--border);background:var(--surface);color:var(--text);flex:1;min-width:180px">
+        </div>
+        <div id="usersList"><div class="loading-spinner"><div class="spinner"></div>読み込み中...</div></div>
       </section>
 
     </main>

--- a/firestore.rules
+++ b/firestore.rules
@@ -26,16 +26,24 @@ service cloud.firestore {
       return isAuthenticated() && request.auth.uid == userId;
     }
 
+    function isAdmin() {
+      return isAuthenticated()
+        && exists(/databases/$(database)/documents/users/$(request.auth.uid))
+        && get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'admin';
+    }
+
     // =============================================
     // Users collection
     // =============================================
     match /users/{userId} {
-      // Users can read their own profile
-      allow read: if isOwner(userId);
+      // Users can read their own profile; admins can read all
+      allow read: if isOwner(userId) || isAdmin();
       // Users can create their own profile during registration
       allow create: if isOwner(userId);
-      // Users can update their own profile
-      allow update: if isOwner(userId);
+      // Users can update their own profile; admins can update any
+      allow update: if isOwner(userId) || isAdmin();
+      // Only admins can delete user profiles
+      allow delete: if isAdmin();
     }
 
     // =============================================

--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@ a{text-decoration:none;color:inherit}
 .load-crest-img{
   width:80px;height:80px;margin-bottom:28px;
   object-fit:contain;
-  filter:brightness(0) invert(1);
+  position:relative;z-index:2;
   animation:crestAppear .6s ease .1s both;
 }
 @keyframes crestAppear{from{opacity:0;transform:scale(.85)}to{opacity:1;transform:scale(1)}}
@@ -435,7 +435,7 @@ a{text-decoration:none;color:inherit}
 .pwa-mode .layout{padding-top:calc(var(--header-h) + var(--safe-t))!important}
 .pwa-mode .sidebar{top:calc(var(--header-h) + var(--safe-t))}
 
-.pg-header{margin-bottom:24px;padding-bottom:18px;border-bottom:1.5px solid var(--border)}
+.pg-header{margin-bottom:24px;padding-top:40px;padding-bottom:18px;border-bottom:1.5px solid var(--border)}
 .breadcrumb{display:flex;align-items:center;gap:5px;font-size:11.5px;color:var(--text-3);margin-bottom:8px}
 .breadcrumb span{cursor:pointer;transition:color .12s}
 .breadcrumb span:hover{color:var(--enjii)}
@@ -464,8 +464,7 @@ a{text-decoration:none;color:inherit}
 .hb-crest{
   width:38px;height:38px;border-radius:50%;
   object-fit:contain;
-  filter:brightness(0) invert(1);
-  position:relative;z-index:1;
+  position:relative;z-index:2;
 }
 .hb-ttl{
   font-family:'Noto Serif JP',serif;font-size:9.5px;font-weight:600;
@@ -1603,12 +1602,16 @@ select.cf-input{cursor:pointer}
           </div>
           <div class="cf-field">
             <label class="cf-label">事由<span class="cf-req">必須</span></label>
-            <select class="cf-input" id="applyReason">
+            <select class="cf-input" id="applyReason" onchange="toggleReasonDetail()">
               <option value="部活動">部活動</option>
               <option value="生徒会活動">生徒会活動</option>
               <option value="学校行事">学校行事</option>
               <option value="その他">その他</option>
             </select>
+          </div>
+          <div class="cf-field" id="applyReasonDetailField" style="display:none">
+            <label class="cf-label" id="applyReasonDetailLabel">部活動名<span class="cf-req">必須</span></label>
+            <input class="cf-input" id="applyReasonDetail" type="text" placeholder="">
           </div>
           <div class="cf-field">
             <label class="cf-label">公欠日<span class="cf-req">必須</span>
@@ -1757,7 +1760,7 @@ const BN_MAP={
   contact:'',apply:'apply',mypage:'mypage',coming:''
 };
 
-function nav(page){
+function nav(page, skipHash){
   PAGES.forEach(p=>{
     const el=document.getElementById('pg-'+p);
     if(el) el.classList.toggle('on',p===page);
@@ -1780,7 +1783,26 @@ function nav(page){
     document.getElementById('sbOverlay').classList.remove('open');
   }
   closeSD();
+  // URLハッシュを更新（ブラウザ戻る・進む対応）
+  if(!skipHash && location.hash !== '#'+page){
+    history.pushState({page:page}, '', '#'+page);
+  }
 }
+// ハッシュからページを復元
+function restoreFromHash(){
+  const hash = location.hash.replace('#','');
+  if(hash && PAGES.includes(hash)){
+    nav(hash, true);
+  }
+}
+// popstate（ブラウザ戻る・進む）
+window.addEventListener('popstate', function(){
+  restoreFromHash();
+});
+// 初期ハッシュ復元
+window.addEventListener('load', function(){
+  setTimeout(restoreFromHash, 100);
+});
 
 /* =================================
    SIDEBAR / MORE
@@ -1801,14 +1823,24 @@ function closeMore(){
 /* =================================
    DARK MODE
 ================================= */
-let darkMode=false;
-function toggleTheme(){
-  darkMode=!darkMode;
-  document.documentElement.setAttribute('data-theme',darkMode?'dark':'');
+let darkMode = localStorage.getItem('mito1_theme') === 'dark';
+// 初期テーマ反映（ちらつき防止のため即座に適用）
+if(darkMode){
+  document.documentElement.setAttribute('data-theme','dark');
+}
+function applyThemeIcon(){
   const icon=document.getElementById('themeIcon');
+  if(!icon) return;
   icon.innerHTML=darkMode
     ?'<circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>'
     :'<path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>';
+}
+applyThemeIcon();
+function toggleTheme(){
+  darkMode=!darkMode;
+  document.documentElement.setAttribute('data-theme',darkMode?'dark':'');
+  localStorage.setItem('mito1_theme',darkMode?'dark':'light');
+  applyThemeIcon();
 }
 
 /* =================================
@@ -2273,6 +2305,28 @@ function updateAuthUI() {
 // =============================================
 // 公欠申請送信
 // =============================================
+// 事由に応じて詳細入力欄の表示切替
+window.toggleReasonDetail = function() {
+  const reason = document.getElementById('applyReason').value
+  const field = document.getElementById('applyReasonDetailField')
+  const label = document.getElementById('applyReasonDetailLabel')
+  const input = document.getElementById('applyReasonDetail')
+  if (reason === '部活動') {
+    field.style.display = ''
+    label.innerHTML = '部活動名<span class="cf-req">必須</span>'
+    input.placeholder = '例: 野球部'
+  } else if (reason === 'その他') {
+    field.style.display = ''
+    label.innerHTML = '内容<span class="cf-req">必須</span>'
+    input.placeholder = '例: 大学のオープンキャンパス参加'
+  } else {
+    field.style.display = 'none'
+    input.value = ''
+  }
+}
+// 初期表示で部活動の場合に表示
+setTimeout(()=>{ window.toggleReasonDetail() }, 0)
+
 window.addDateField = function() {
   const wrap = document.getElementById('applyDatesWrap')
   const div = document.createElement('div')
@@ -2289,6 +2343,7 @@ window.submitApply = async function() {
 
   const title           = document.getElementById('applyTitle').value.trim()
   const reason          = document.getElementById('applyReason').value
+  const reasonDetail    = document.getElementById('applyReasonDetail').value.trim()
   const supervisorEmail = document.getElementById('applySupervisorEmail').value.trim()
   const homeRoomEmail   = document.getElementById('applyHomeRoomEmail').value.trim()
   const dates = [...document.querySelectorAll('.apply-date')]
@@ -2299,15 +2354,19 @@ window.submitApply = async function() {
   errEl.style.display = 'none'
 
   if (!title)                         { showErr('件名を入力してください'); return }
+  if ((reason === '部活動' || reason === 'その他') && !reasonDetail) {
+    showErr(reason === '部活動' ? '部活動名を入力してください' : '内容を入力してください'); return
+  }
   if (dates.length === 0)             { showErr('公欠日を1日以上入力してください'); return }
   if (!supervisorEmail.includes('@')) { showErr('顧問のメールアドレスを正しく入力してください'); return }
   if (!homeRoomEmail.includes('@'))   { showErr('担任のメールアドレスを正しく入力してください'); return }
 
   // 確認ダイアログ
   const datesStr = dates.join('、')
+  const reasonDisplay = reasonDetail ? `${reason}（${reasonDetail}）` : reason
   const ok = confirm(
     `以下の内容で申請します。\n\n` +
-    `件名: ${title}\n公欠日: ${datesStr}\n事由: ${reason}\n` +
+    `件名: ${title}\n公欠日: ${datesStr}\n事由: ${reasonDisplay}\n` +
     `顧問: ${supervisorEmail}\n担任: ${homeRoomEmail}\n\nよろしいですか？`
   )
   if (!ok) return
@@ -2321,7 +2380,7 @@ window.submitApply = async function() {
       studentId:      _currentUser.uid,
       studentName:    (_currentProfile && _currentProfile.name) || _currentUser.email,
       studentEmail:   _currentUser.email,
-      title, reason, dates, supervisorEmail, homeRoomEmail,
+      title, reason, reasonDetail, dates, supervisorEmail, homeRoomEmail,
     })
     document.getElementById('applyForm').style.display = 'none'
     document.getElementById('applyDone').style.display = ''
@@ -2351,6 +2410,7 @@ window.submitApply = async function() {
 
 window.resetApply = function() {
   document.getElementById('applyTitle').value = ''
+  document.getElementById('applyReasonDetail').value = ''
   document.getElementById('applySupervisorEmail').value = ''
   document.getElementById('applyHomeRoomEmail').value   = ''
   // 日付フィールドを1つにリセット
@@ -2457,8 +2517,8 @@ window.loadMyCases = async function() {
 
 // マイページ表示時に自動読み込み
 const origNav = window.nav
-window.nav = function(page) {
-  origNav(page)
+window.nav = function(page, skipHash) {
+  origNav(page, skipHash)
   if (page === 'mypage') window.loadMyCases()
 }
 

--- a/src/admin/main.js
+++ b/src/admin/main.js
@@ -7,8 +7,9 @@ import {
 import {
   collection, doc, getDocs, getDoc,
   addDoc, setDoc, updateDoc, deleteDoc,
-  orderBy, query
+  orderBy, query, where,
 } from 'firebase/firestore'
+import { getCurrentProfile } from '../auth.js'
 
 // =============================================
 // STATE
@@ -71,10 +72,20 @@ document.addEventListener('DOMContentLoaded', () => {
 })
 
 // =============================================
-// AUTH
+// AUTH — 管理者権限チェック
 // =============================================
-onAuthStateChanged(auth, user => {
+onAuthStateChanged(auth, async user => {
   if (user) {
+    // Firestoreでユーザーのロールを確認
+    const profile = await getCurrentProfile(user)
+    if (!profile || profile.role !== 'admin') {
+      // 管理者権限がない場合はログイン画面に戻す
+      document.getElementById('loginErr').textContent = 'この機能は管理者のみアクセスできます'
+      document.getElementById('loginScreen').classList.remove('hide')
+      document.getElementById('appShell').classList.remove('show')
+      await signOut(auth)
+      return
+    }
     document.getElementById('loginScreen').classList.add('hide')
     document.getElementById('appShell').classList.add('show')
     document.getElementById('headerUser').textContent = user.email
@@ -93,7 +104,8 @@ async function doLogin() {
   err.textContent = ''
   btn.disabled = true
   try {
-    await signInWithEmailAndPassword(auth, email, pass)
+    const cred = await signInWithEmailAndPassword(auth, email, pass)
+    // ログイン成功後、ロールチェックはonAuthStateChangedで行われる
   } catch (e) {
     const msgs = {
       'auth/invalid-credential': 'メールアドレスまたはパスワードが違います',
@@ -138,6 +150,7 @@ async function loadSection(sec) {
     case 'council-rules':    return loadList('council-rules', renderArticleList('councilRulesList'))
     case 'inquiries':        return loadInquiries()
     case 'cases':            return loadAdminCases()
+    case 'users':            return loadUsers()
   }
 }
 
@@ -921,6 +934,10 @@ window.loadInquiries = async function() {
               style="font-size:11px;padding:6px 12px;border:none;border-radius:6px;background:var(--navy);cursor:pointer;color:#fff">
               返信内容を保存
             </button>
+            <button onclick="sendReplyEmail('${item.id}')"
+              style="font-size:11px;padding:6px 12px;border:none;border-radius:6px;background:#27ae60;cursor:pointer;color:#fff">
+              📧 メールで送信
+            </button>
             <select onchange="changeStatus('${item.id}',this.value)"
               style="font-size:11px;padding:6px 8px;border:1px solid var(--border);border-radius:6px;background:var(--surface);color:var(--text)">
               ${Object.entries(STATUS_LABELS).map(([k,v])=>`<option value="${k}"${item.status===k?' selected':''}>${v}</option>`).join('')}
@@ -972,6 +989,48 @@ window.saveReply = async function(id) {
   await updateDoc(doc(db, 'inquiries', id), { reply: ta.value, status: 'replied' })
   showToast('返信内容を保存しました')
   loadInquiries()
+}
+
+// メールで返信を送信
+window.sendReplyEmail = async function(id) {
+  const ta = document.getElementById('reply-'+id)
+  if (!ta || !ta.value.trim()) { showToast('返信内容を入力してください'); return }
+
+  // お問い合わせデータを取得
+  const snap = await getDoc(doc(db, 'inquiries', id))
+  if (!snap.exists()) { showToast('お問い合わせが見つかりません'); return }
+  const data = snap.data()
+  if (!data.email) { showToast('送信先メールアドレスがありません'); return }
+
+  const btn = event.target
+  btn.disabled = true
+  btn.textContent = '送信中...'
+
+  try {
+    const res = await fetch(AI_URL + '/send-reply', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({
+        recipientEmail: data.email,
+        recipientName: data.name || '',
+        subject: data.subject || 'お問い合わせ',
+        replyBody: ta.value.trim(),
+        appBaseUrl: window.location.origin + '/mito1-digital-studenthandbook',
+      })
+    })
+    if (!res.ok) {
+      const detail = await res.text().catch(() => '')
+      throw new Error(`送信失敗 (${res.status}): ${detail}`)
+    }
+    // 返信内容も保存
+    await updateDoc(doc(db, 'inquiries', id), { reply: ta.value, status: 'replied' })
+    showToast('メールを送信しました')
+    loadInquiries()
+  } catch(e) {
+    showToast('メール送信エラー: ' + e.message)
+    btn.disabled = false
+    btn.textContent = '📧 メールで送信'
+  }
 }
 
 window.changeStatus = async function(id, status) {
@@ -1038,7 +1097,7 @@ window.loadAdminCases = async function() {
           </div>
           <div style="font-size:15px;font-weight:600;color:var(--text);margin-bottom:4px">${escHtml(c.title||'')}</div>
           <div style="font-size:12px;color:var(--text-3);margin-bottom:2px">申請者: <strong>${escHtml(c.studentName||'')}</strong> &lt;${escHtml(c.studentEmail||'')}&gt;</div>
-          <div style="font-size:12px;color:var(--text-3);margin-bottom:2px">公欠日: ${escHtml(datesStr)} ／ 事由: ${escHtml(c.reason||'')}</div>
+          <div style="font-size:12px;color:var(--text-3);margin-bottom:2px">公欠日: ${escHtml(datesStr)} ／ 事由: ${escHtml(c.reasonDetail ? c.reason + '（' + c.reasonDetail + '）' : (c.reason||''))}</div>
           <div style="font-size:11.5px;color:var(--text-3)">顧問: ${escHtml(c.supervisorEmail||'')} ／ 担任: ${escHtml(c.homeRoomEmail||'')}</div>
           ${progressBar}
           <div style="margin-top:10px;padding-top:10px;border-top:1px solid var(--border);display:flex;justify-content:flex-end">
@@ -1069,5 +1128,230 @@ window.deleteAdminCase = async function(caseId) {
     } else {
       alert('削除に失敗しました: ' + msg)
     }
+  }
+}
+
+// =============================================
+// ユーザー管理
+// =============================================
+const ROLE_LABELS = { student: '生徒', teacher: '先生', admin: '管理者' }
+const ROLE_COLORS = { student: '#004085', teacher: '#856404', admin: '#155724' }
+const ROLE_BGS    = { student: '#cce5ff', teacher: '#fff3cd', admin: '#d4edda' }
+
+let allUsers = []
+let userFilters = { role: 'all', grade: 'all', class: 'all', search: '' }
+
+async function loadUsers() {
+  const el = document.getElementById('usersList')
+  if (!el) return
+  el.innerHTML = '<div class="loading-spinner"><div class="spinner"></div>読み込み中...</div>'
+
+  try {
+    const snap = await getDocs(collection(db, 'users'))
+    allUsers = snap.docs.map(d => ({ id: d.id, ...d.data() }))
+    renderUsers()
+  } catch(e) {
+    el.innerHTML = `<div style="padding:20px;color:#c0392b">読み込みエラー: ${e.message}</div>`
+  }
+}
+
+function renderUsers() {
+  const el = document.getElementById('usersList')
+  if (!el) return
+
+  let filtered = [...allUsers]
+
+  // ロールフィルタ
+  if (userFilters.role !== 'all') {
+    filtered = filtered.filter(u => u.role === userFilters.role)
+  }
+  // 学年フィルタ
+  if (userFilters.grade !== 'all') {
+    filtered = filtered.filter(u => String(u.grade) === userFilters.grade)
+  }
+  // クラスフィルタ
+  if (userFilters.class !== 'all') {
+    filtered = filtered.filter(u => String(u.class) === userFilters.class)
+  }
+  // 検索フィルタ
+  if (userFilters.search) {
+    const kw = userFilters.search.toLowerCase()
+    filtered = filtered.filter(u =>
+      (u.name||'').toLowerCase().includes(kw) ||
+      (u.email||'').toLowerCase().includes(kw)
+    )
+  }
+
+  // ソート: 先生→管理者→生徒（学年→クラス→番号）
+  filtered.sort((a,b) => {
+    const ro = { admin:0, teacher:1, student:2 }
+    const rr = (ro[a.role]||9) - (ro[b.role]||9)
+    if (rr !== 0) return rr
+    if (a.grade !== b.grade) return (a.grade||0) - (b.grade||0)
+    if (a.class !== b.class) return (a.class||0) - (b.class||0)
+    return (a.number||0) - (b.number||0)
+  })
+
+  if (!filtered.length) {
+    el.innerHTML = '<div style="padding:32px;text-align:center;color:var(--text-3)">該当するユーザーはいません</div>'
+    return
+  }
+
+  el.innerHTML = `
+    <div style="margin-bottom:8px;font-size:12px;color:var(--text-3)">
+      全${allUsers.length}件中 ${filtered.length}件表示
+    </div>
+    <div style="overflow-x:auto">
+      <table style="width:100%;border-collapse:collapse;font-size:13px">
+        <thead>
+          <tr style="background:var(--surface2)">
+            <th style="padding:9px 12px;text-align:left;border-bottom:2px solid var(--border);font-weight:600;color:var(--text-3);font-size:11px">氏名</th>
+            <th style="padding:9px 12px;text-align:left;border-bottom:2px solid var(--border);font-weight:600;color:var(--text-3);font-size:11px">メール</th>
+            <th style="padding:9px 12px;text-align:center;border-bottom:2px solid var(--border);font-weight:600;color:var(--text-3);font-size:11px">ロール</th>
+            <th style="padding:9px 12px;text-align:center;border-bottom:2px solid var(--border);font-weight:600;color:var(--text-3);font-size:11px">学年</th>
+            <th style="padding:9px 12px;text-align:center;border-bottom:2px solid var(--border);font-weight:600;color:var(--text-3);font-size:11px">クラス</th>
+            <th style="padding:9px 12px;text-align:center;border-bottom:2px solid var(--border);font-weight:600;color:var(--text-3);font-size:11px">番号</th>
+            <th style="padding:9px 12px;text-align:center;border-bottom:2px solid var(--border);font-weight:600;color:var(--text-3);font-size:11px">管理者</th>
+            <th style="padding:9px 12px;border-bottom:2px solid var(--border)"></th>
+          </tr>
+        </thead>
+        <tbody>
+          ${filtered.map(u => `
+            <tr>
+              <td style="padding:9px 12px;border-bottom:1px solid var(--border-2);color:var(--text);font-weight:500">${escHtml(u.name||'')}</td>
+              <td style="padding:9px 12px;border-bottom:1px solid var(--border-2);color:var(--text-2);font-size:12px">${escHtml(u.email||'')}</td>
+              <td style="padding:9px 12px;border-bottom:1px solid var(--border-2);text-align:center">
+                <span style="font-size:10px;font-weight:700;padding:2px 8px;border-radius:4px;color:${ROLE_COLORS[u.role]||'#888'};background:${ROLE_BGS[u.role]||'#eee'}">${ROLE_LABELS[u.role]||u.role||'不明'}</span>
+              </td>
+              <td style="padding:9px 12px;border-bottom:1px solid var(--border-2);text-align:center;color:var(--text-2)">${u.grade||'—'}</td>
+              <td style="padding:9px 12px;border-bottom:1px solid var(--border-2);text-align:center;color:var(--text-2)">${u.class||'—'}</td>
+              <td style="padding:9px 12px;border-bottom:1px solid var(--border-2);text-align:center;color:var(--text-2)">${u.number||'—'}</td>
+              <td style="padding:9px 12px;border-bottom:1px solid var(--border-2);text-align:center">
+                ${u.role === 'admin' ? '<span style="color:#27ae60;font-weight:700">✓</span>' : '<span style="color:var(--text-3)">—</span>'}
+              </td>
+              <td style="padding:9px 12px;border-bottom:1px solid var(--border-2)">
+                <div style="display:flex;gap:4px;justify-content:flex-end">
+                  <button onclick="editUser('${u.id}')"
+                    style="font-size:11px;padding:4px 10px;border:1px solid var(--border);border-radius:5px;background:var(--surface);cursor:pointer;color:var(--text-2);font-family:inherit">
+                    編集
+                  </button>
+                  <button onclick="deleteUser('${u.id}','${escHtml(u.name||u.email||'')}')"
+                    style="font-size:11px;padding:4px 10px;border:1px solid #e74c3c;border-radius:5px;background:transparent;cursor:pointer;color:#e74c3c;font-family:inherit">
+                    削除
+                  </button>
+                </div>
+              </td>
+            </tr>
+          `).join('')}
+        </tbody>
+      </table>
+    </div>`
+}
+
+window.filterUsers = function(type, value) {
+  userFilters[type] = value
+  renderUsers()
+}
+
+window.searchUsers = function(q) {
+  userFilters.search = q
+  renderUsers()
+}
+
+window.editUser = async function(uid) {
+  const user = allUsers.find(u => u.id === uid)
+  if (!user) return
+
+  const overlay = document.getElementById('modalOverlay')
+  document.getElementById('modalTitle').textContent = '編集 — ユーザー'
+  document.getElementById('modalBody').innerHTML = `
+    <div class="form-row">
+      <label>氏名</label>
+      <input type="text" id="f_user_name" value="${escHtml(user.name||'')}">
+    </div>
+    <div class="form-row">
+      <label>メールアドレス</label>
+      <input type="email" id="f_user_email" value="${escHtml(user.email||'')}" disabled style="opacity:0.6;cursor:not-allowed">
+      <div style="font-size:10px;color:var(--text-3);margin-top:3px">※メールアドレスはFirebase Authenticationで管理されるためここでは変更できません</div>
+    </div>
+    <div class="form-row">
+      <label>ロール</label>
+      <select id="f_user_role">
+        <option value="student" ${user.role==='student'?'selected':''}>生徒</option>
+        <option value="teacher" ${user.role==='teacher'?'selected':''}>先生</option>
+        <option value="admin" ${user.role==='admin'?'selected':''}>管理者</option>
+      </select>
+    </div>
+    <div class="form-row-2 form-row" id="f_user_student_fields" style="${user.role==='student'?'':'display:none'}">
+      <div>
+        <label>学年</label>
+        <select id="f_user_grade">
+          <option value="">—</option>
+          <option value="1" ${user.grade==1?'selected':''}>1年</option>
+          <option value="2" ${user.grade==2?'selected':''}>2年</option>
+          <option value="3" ${user.grade==3?'selected':''}>3年</option>
+        </select>
+      </div>
+      <div>
+        <label>クラス</label>
+        <select id="f_user_class">
+          <option value="">—</option>
+          ${[1,2,3,4,5,6].map(i=>`<option value="${i}" ${user.class==i?'selected':''}>${i}組</option>`).join('')}
+        </select>
+      </div>
+    </div>
+    <div class="form-row" id="f_user_number_field" style="${user.role==='student'?'':'display:none'}">
+      <label>出席番号</label>
+      <input type="number" id="f_user_number" value="${user.number||''}" min="1" max="50">
+    </div>
+    <script>
+      document.getElementById('f_user_role').addEventListener('change', function(){
+        const isStudent = this.value === 'student';
+        document.getElementById('f_user_student_fields').style.display = isStudent ? '' : 'none';
+        document.getElementById('f_user_number_field').style.display = isStudent ? '' : 'none';
+      });
+    <\/script>
+  `
+
+  // Rebind modal save for user editing
+  const saveBtn = document.getElementById('modalSaveBtn')
+  const origHandler = saveBtn.onclick
+  saveBtn.onclick = async function() {
+    saveBtn.disabled = true
+    try {
+      const data = {
+        name: document.getElementById('f_user_name').value.trim(),
+        role: document.getElementById('f_user_role').value,
+      }
+      if (data.role === 'student') {
+        const g = document.getElementById('f_user_grade').value
+        const c = document.getElementById('f_user_class').value
+        const n = document.getElementById('f_user_number').value
+        if (g) data.grade = Number(g)
+        if (c) data.class = c
+        if (n) data.number = Number(n)
+      }
+      await updateDoc(doc(db, 'users', uid), data)
+      showToast('ユーザーを更新しました')
+      closeModal()
+      loadUsers()
+    } catch(e) {
+      showToast('エラー: ' + e.message)
+    }
+    saveBtn.disabled = false
+    saveBtn.onclick = origHandler
+  }
+
+  overlay.classList.add('open')
+}
+
+window.deleteUser = async function(uid, name) {
+  if (!confirm(`ユーザー「${name}」の登録情報を削除しますか？\n※Firebase Authenticationのアカウント自体はFirebase Consoleから削除する必要があります。`)) return
+  try {
+    await deleteDoc(doc(db, 'users', uid))
+    showToast('ユーザー情報を削除しました')
+    loadUsers()
+  } catch(e) {
+    alert('削除に失敗しました: ' + (e?.message || String(e)))
   }
 }

--- a/src/auth.js
+++ b/src/auth.js
@@ -13,7 +13,7 @@ import {
   setPersistence,
 } from 'firebase/auth'
 import {
-  doc, setDoc, getDoc, serverTimestamp,
+  doc, setDoc, getDoc, getDocs, collection, serverTimestamp,
 } from 'firebase/firestore'
 
 // タブを閉じたらログアウト

--- a/src/auth_page.js
+++ b/src/auth_page.js
@@ -72,8 +72,9 @@ document.getElementById('mainCard').innerHTML = `
 
     <div id="formTeacher" style="display:none">
       <div class="form-group">
-        <label class="form-label">氏名 <span class="req">必須</span></label>
-        <input class="form-input" id="regTeacherName" type="text" placeholder="鈴木 先生">
+        <label class="form-label">氏名（フルネーム） <span class="req">必須</span></label>
+        <input class="form-input" id="regTeacherName" type="text" placeholder="鈴木 太郎">
+        <div style="font-size:11px;color:var(--text-3);margin-top:4px">※「先生」は付けずにフルネームで入力してください。ダッシュボードでは自動で「先生」が付加されます。</div>
       </div>
       <div class="form-group">
         <label class="form-label">メールアドレス <span class="req">必須</span></label>

--- a/src/cases.js
+++ b/src/cases.js
@@ -57,7 +57,7 @@ async function sendEmail(endpoint, payload) {
 // =============================================
 // ケース作成 + 顧問へ承認依頼メール送信
 // =============================================
-export async function createCase({ studentId, studentName, studentEmail, title, reason, dates, supervisorEmail, homeRoomEmail }) {
+export async function createCase({ studentId, studentName, studentEmail, title, reason, reasonDetail, dates, supervisorEmail, homeRoomEmail }) {
   const approveToken = genToken()
   const rejectToken  = genToken()
 
@@ -68,6 +68,7 @@ export async function createCase({ studentId, studentName, studentEmail, title, 
     studentEmail,
     title,
     reason,
+    reasonDetail: reasonDetail || '',
     dates,                    // ["2025-06-14", "2025-06-15"]
     supervisorEmail,
     homeRoomEmail,
@@ -86,7 +87,7 @@ export async function createCase({ studentId, studentName, studentEmail, title, 
   // 顧問へ承認依頼メール送信
   const emailResult = await sendEmail('/send-approval', {
     caseId: ref.id,
-    studentName, title, dates, reason,
+    studentName, title, dates, reason, reasonDetail: reasonDetail || '',
     step: 'supervisor',
     recipientEmail: supervisorEmail,
     recipientRole: 'supervisor',

--- a/src/main.js
+++ b/src/main.js
@@ -382,11 +382,12 @@ async function loadCouncilActivities() {
 // 全条文・説明文・前文を完全に格納
 // =============================================
 async function buildSearchIndex() {
-  const [rules, special, events, history, charter, councilRules, songs, goals] = await Promise.all([
+  const [rules, special, events, history, principals, charter, councilRules, songs, goals] = await Promise.all([
     fetchOrdered('rules'),
     fetchOrdered('special'),
     fetchOrdered('events'),
     fetchOrdered('history'),
+    fetchOrdered('principals'),
     fetchOrdered('council-charter'),
     fetchOrdered('council-rules'),
     fetchOrdered('songs'),
@@ -455,6 +456,16 @@ async function buildSearchIndex() {
       snip: item.event || '',
       page: 'about',
       tags: '沿革 歴史',
+    })
+  })
+
+  principals.forEach(item => {
+    index.push({
+      path: '歴代校長一覧',
+      title: `${item.gen || ''} ${item.name || ''}`,
+      snip: `${item.name || ''} ${item.term || ''}`,
+      page: 'principals',
+      tags: '歴代校長 校長',
     })
   })
 
@@ -530,7 +541,7 @@ async function buildSearchIndex() {
   window.DYNAMIC_SEARCH_INDEX = index
 
   // 全データをキャッシュ（AI用）
-  window._allArticleData = { rules, special, charter, councilRules, specialContent, charterContent, councilRulesContent }
+  window._allArticleData = { rules, special, charter, councilRules, principals, songs, history, specialContent, charterContent, councilRulesContent }
 }
 
 // =============================================
@@ -622,6 +633,35 @@ function buildAIContext() {
       if (r.body) text += `\n${r.body}`
       if (r.items?.length) text += '\n' + r.items.map((it, i) => `  ${i + 1}. ${it}`).join('\n')
       lines.push(text)
+    })
+  }
+
+  // 歴代校長
+  if (data.principals?.length) {
+    lines.push('\n========== 歴代校長一覧 ==========')
+    data.principals.forEach(p => {
+      lines.push(`${p.gen || ''} ${p.name || ''} （${p.term || ''}）`)
+    })
+  }
+
+  // 歌詞
+  if (data.songs?.length) {
+    lines.push('\n========== 歌詞 ==========')
+    data.songs.forEach(s => {
+      lines.push(`[${s.type || ''}] ${s.title || ''}`)
+      if (s.lyricist) lines.push(`作詞：${s.lyricist}`)
+      if (s.composer) lines.push(`作曲：${s.composer}`)
+      ;(s.verses || []).forEach((v, i) => {
+        lines.push(`${i + 1}番\n${v}`)
+      })
+    })
+  }
+
+  // 沿革
+  if (data.history?.length) {
+    lines.push('\n========== 本校の沿革 ==========')
+    data.history.forEach(h => {
+      lines.push(`${h.year || ''} ${h.event || ''}`)
     })
   }
 

--- a/src/teacher_page.js
+++ b/src/teacher_page.js
@@ -95,7 +95,7 @@ function renderCases() {
             <div class="case-title">${esc(c.title)}</div>
             <div class="case-meta">
               <span>申請者: ${esc(c.studentName)}</span>
-              <span>${esc(c.reason||'')}</span>
+              <span>${esc(c.reasonDetail ? c.reason + '（' + c.reasonDetail + '）' : (c.reason||''))}</span>
               <span>${c.createdAt?.toDate ? c.createdAt.toDate().toLocaleDateString('ja') : ''}</span>
             </div>
             <div class="case-dates">📅 ${esc(datesStr)}</div>

--- a/workers/index.js
+++ b/workers/index.js
@@ -60,6 +60,7 @@ export default {
 
     if (url.pathname === '/send-approval') return sendApproval(body, env)
     if (url.pathname === '/send-complete')  return sendComplete(body, env)
+    if (url.pathname === '/send-reply')     return sendReply(body, env)
 
     // Default -> Gemini proxy
     return gemini(body, env)
@@ -135,7 +136,7 @@ async function gemini(body, env) {
 // -- Approval request email ---------------------------------------------
 async function sendApproval(body, env) {
   const {
-    studentName, title, dates, reason,
+    studentName, title, dates, reason, reasonDetail,
     step, recipientEmail, recipientRole,
     supervisorEmail, approveToken, rejectToken, appBaseUrl,
   } = body
@@ -147,36 +148,37 @@ async function sendApproval(body, env) {
 
   const base     = appBaseUrl || env.APP_BASE_URL || 'https://ryuto-devs.github.io/mito1-digital-studenthandbook'
   const datesStr = (dates || []).join(', ')
-  const roleName = recipientRole === 'supervisor' ? 'Supervisor' : 'Homeroom Teacher'
+  const roleName = recipientRole === 'supervisor' ? '顧問' : '担任'
+  const reasonDisplay = reasonDetail ? `${reason}（${reasonDetail}）` : (reason || '部活動')
   // Always include caseId in approve/reject URLs
   const approveUrl = `${base}/approve.html?caseId=${body.caseId}&token=${approveToken}&action=approve`
   const rejectUrl  = `${base}/approve.html?caseId=${body.caseId}&token=${rejectToken}&action=reject`
   const supNote    = step === 'homeroom'
-    ? `<p style="color:#27ae60;background:#eafaf1;padding:10px 14px;border-radius:6px;font-size:13px;margin:12px 0">Supervisor (${supervisorEmail}) has already approved.</p>`
+    ? `<p style="color:#27ae60;background:#eafaf1;padding:10px 14px;border-radius:6px;font-size:13px;margin:12px 0">顧問（${supervisorEmail}）が承認済みです。</p>`
     : ''
 
   const html = `<!DOCTYPE html><html lang="ja"><head><meta charset="UTF-8"></head>
-<body style="font-family:sans-serif;background:#f5f5f5;padding:24px;margin:0">
+<body style="font-family:'Helvetica Neue',Arial,'Noto Sans JP',sans-serif;background:#f5f5f5;padding:24px;margin:0">
 <div style="max-width:560px;margin:0 auto;background:#fff;border-radius:12px;overflow:hidden;box-shadow:0 2px 12px rgba(0,0,0,.08)">
-  <div style="background:#1a2744;padding:20px 28px"><div style="color:#fff;font-size:18px;font-weight:700">Mito Daiichi High School</div><div style="color:#a0b0cc;font-size:12px;margin-top:2px">Digital Student Handbook - Absence Application System</div></div>
+  <div style="background:#1a2744;padding:20px 28px"><div style="color:#fff;font-size:18px;font-weight:700">水戸第一高等学校</div><div style="color:#a0b0cc;font-size:12px;margin-top:2px">デジタル生徒手帳 公欠申請システム</div></div>
   <div style="padding:28px">
-    <p style="color:#333;font-size:15px;margin:0 0 16px">${roleName}<br><br>Please review the following absence application.</p>
+    <p style="color:#333;font-size:15px;margin:0 0 16px">${roleName}の先生<br><br>以下の公欠申請の承認をお願いいたします。</p>
     ${supNote}
     <table style="width:100%;border-collapse:collapse;font-size:13px;margin:16px 0">
-      <tr style="background:#f8f9fa"><td style="padding:10px 14px;border:1px solid #e0e0e0;font-weight:600;width:30%">Applicant</td><td style="padding:10px 14px;border:1px solid #e0e0e0">${studentName}</td></tr>
-      <tr><td style="padding:10px 14px;border:1px solid #e0e0e0;font-weight:600">Subject</td><td style="padding:10px 14px;border:1px solid #e0e0e0">${title}</td></tr>
-      <tr style="background:#f8f9fa"><td style="padding:10px 14px;border:1px solid #e0e0e0;font-weight:600">Reason</td><td style="padding:10px 14px;border:1px solid #e0e0e0">${reason||'Club activity'}</td></tr>
-      <tr><td style="padding:10px 14px;border:1px solid #e0e0e0;font-weight:600">Absence Dates</td><td style="padding:10px 14px;border:1px solid #e0e0e0">${datesStr}</td></tr>
+      <tr style="background:#f8f9fa"><td style="padding:10px 14px;border:1px solid #e0e0e0;font-weight:600;width:30%">申請者</td><td style="padding:10px 14px;border:1px solid #e0e0e0">${studentName}</td></tr>
+      <tr><td style="padding:10px 14px;border:1px solid #e0e0e0;font-weight:600">件名</td><td style="padding:10px 14px;border:1px solid #e0e0e0">${title}</td></tr>
+      <tr style="background:#f8f9fa"><td style="padding:10px 14px;border:1px solid #e0e0e0;font-weight:600">事由</td><td style="padding:10px 14px;border:1px solid #e0e0e0">${reasonDisplay}</td></tr>
+      <tr><td style="padding:10px 14px;border:1px solid #e0e0e0;font-weight:600">公欠日</td><td style="padding:10px 14px;border:1px solid #e0e0e0">${datesStr}</td></tr>
     </table>
     <div style="display:flex;gap:12px;margin-top:24px">
-      <a href="${approveUrl}" style="flex:1;display:block;text-align:center;background:#1a2744;color:#fff;padding:14px;border-radius:8px;text-decoration:none;font-size:14px;font-weight:700">Approve</a>
-      <a href="${rejectUrl}" style="flex:1;display:block;text-align:center;background:#fff;color:#e74c3c;border:1.5px solid #e74c3c;padding:14px;border-radius:8px;text-decoration:none;font-size:14px;font-weight:700">Reject</a>
+      <a href="${approveUrl}" style="flex:1;display:block;text-align:center;background:#1a2744;color:#fff;padding:14px;border-radius:8px;text-decoration:none;font-size:14px;font-weight:700">承認する</a>
+      <a href="${rejectUrl}" style="flex:1;display:block;text-align:center;background:#fff;color:#e74c3c;border:1.5px solid #e74c3c;padding:14px;border-radius:8px;text-decoration:none;font-size:14px;font-weight:700">差し戻す</a>
     </div>
-    <p style="font-size:11px;color:#999;margin-top:20px">This link is valid for 7 days. You can also manage from the <a href="${base}/teacher.html" style="color:#1a2744">Teacher Dashboard</a>.</p>
+    <p style="font-size:11px;color:#999;margin-top:20px">このリンクの有効期限は7日間です。<a href="${base}/teacher.html" style="color:#1a2744">先生用ダッシュボード</a>からも操作できます。</p>
   </div>
 </div></body></html>`
 
-  const r = await resend(env, { to: recipientEmail, subject: `[Absence Application] ${studentName} - ${title} (${datesStr})`, html })
+  const r = await resend(env, { to: recipientEmail, subject: `【公欠申請】${studentName} - ${title}（${datesStr}）`, html })
   if (!r.ok) {
     const detail = await r.text().catch(() => 'Unknown error')
     console.error('[send-approval] Resend API error:', r.status, detail)
@@ -197,25 +199,62 @@ async function sendComplete(body, env) {
   const datesStr = (dates || []).join(', ')
 
   const html = `<!DOCTYPE html><html lang="ja"><head><meta charset="UTF-8"></head>
-<body style="font-family:sans-serif;background:#f5f5f5;padding:24px;margin:0">
+<body style="font-family:'Helvetica Neue',Arial,'Noto Sans JP',sans-serif;background:#f5f5f5;padding:24px;margin:0">
 <div style="max-width:560px;margin:0 auto;background:#fff;border-radius:12px;overflow:hidden;box-shadow:0 2px 12px rgba(0,0,0,.08)">
-  <div style="background:#1a2744;padding:20px 28px"><div style="color:#fff;font-size:18px;font-weight:700">Mito Daiichi High School</div><div style="color:#a0b0cc;font-size:12px;margin-top:2px">Digital Student Handbook - Absence Application System</div></div>
+  <div style="background:#1a2744;padding:20px 28px"><div style="color:#fff;font-size:18px;font-weight:700">水戸第一高等学校</div><div style="color:#a0b0cc;font-size:12px;margin-top:2px">デジタル生徒手帳 公欠申請システム</div></div>
   <div style="padding:28px;text-align:center">
     <div style="font-size:48px;margin-bottom:12px">&#10004;</div>
-    <div style="font-size:18px;font-weight:700;color:#1a2744;margin-bottom:8px">Absence Application Approved</div>
-    <p style="color:#333;font-size:14px;margin-bottom:16px">${studentName}'s application has been approved by both supervisor and homeroom teacher.</p>
+    <div style="font-size:18px;font-weight:700;color:#1a2744;margin-bottom:8px">公欠申請が承認されました</div>
+    <p style="color:#333;font-size:14px;margin-bottom:16px">${studentName} さんの公欠申請が顧問・担任の両方に承認されました。</p>
     <table style="width:100%;border-collapse:collapse;font-size:13px;margin:16px 0;text-align:left">
-      <tr style="background:#f8f9fa"><td style="padding:10px 14px;border:1px solid #e0e0e0;font-weight:600;width:30%">Subject</td><td style="padding:10px 14px;border:1px solid #e0e0e0">${title}</td></tr>
-      <tr><td style="padding:10px 14px;border:1px solid #e0e0e0;font-weight:600">Absence Dates</td><td style="padding:10px 14px;border:1px solid #e0e0e0">${datesStr}</td></tr>
+      <tr style="background:#f8f9fa"><td style="padding:10px 14px;border:1px solid #e0e0e0;font-weight:600;width:30%">件名</td><td style="padding:10px 14px;border:1px solid #e0e0e0">${title}</td></tr>
+      <tr><td style="padding:10px 14px;border:1px solid #e0e0e0;font-weight:600">公欠日</td><td style="padding:10px 14px;border:1px solid #e0e0e0">${datesStr}</td></tr>
     </table>
-    <a href="${base}" style="display:inline-block;background:#1a2744;color:#fff;padding:13px 28px;border-radius:8px;text-decoration:none;font-size:14px;font-weight:700;margin-top:8px">Open Handbook</a>
+    <a href="${base}/#mypage" style="display:inline-block;background:#1a2744;color:#fff;padding:13px 28px;border-radius:8px;text-decoration:none;font-size:14px;font-weight:700;margin-top:8px">手帳を開く（マイページ）</a>
   </div>
 </div></body></html>`
 
-  const r = await resend(env, { to: studentEmail, subject: `[Approved] Absence Application "${title}" (${datesStr})`, html })
+  const r = await resend(env, { to: studentEmail, subject: `【承認完了】公欠申請「${title}」（${datesStr}）`, html })
   if (!r.ok) {
     const detail = await r.text().catch(() => 'Unknown error')
     console.error('[send-complete] Resend API error:', r.status, detail)
+    return json({ error: 'Email send failed', detail, status: r.status }, 500)
+  }
+  return json({ ok: true })
+}
+
+// -- Inquiry reply email ------------------------------------------------
+async function sendReply(body, env) {
+  const { recipientEmail, recipientName, subject, replyBody, appBaseUrl } = body
+
+  if (!recipientEmail) {
+    return json({ error: 'recipientEmail is required' }, 400)
+  }
+  if (!replyBody) {
+    return json({ error: 'replyBody is required' }, 400)
+  }
+
+  const base = appBaseUrl || env.APP_BASE_URL || ''
+  const replyText = (replyBody || '').replace(/\n/g, '<br>')
+
+  const html = `<!DOCTYPE html><html lang="ja"><head><meta charset="UTF-8"></head>
+<body style="font-family:'Helvetica Neue',Arial,'Noto Sans JP',sans-serif;background:#f5f5f5;padding:24px;margin:0">
+<div style="max-width:560px;margin:0 auto;background:#fff;border-radius:12px;overflow:hidden;box-shadow:0 2px 12px rgba(0,0,0,.08)">
+  <div style="background:#1a2744;padding:20px 28px"><div style="color:#fff;font-size:18px;font-weight:700">水戸第一高等学校</div><div style="color:#a0b0cc;font-size:12px;margin-top:2px">デジタル生徒手帳 お問い合わせ回答</div></div>
+  <div style="padding:28px">
+    <p style="color:#333;font-size:15px;margin:0 0 16px">${recipientName || ''} 様<br><br>お問い合わせいただきありがとうございます。<br>以下の通り回答いたします。</p>
+    <div style="background:#f8f9fa;border-radius:8px;padding:16px 18px;margin:16px 0;font-size:14px;color:#333;line-height:1.8;border-left:4px solid #1a2744">
+      ${replyText}
+    </div>
+    <p style="font-size:12px;color:#999;margin-top:20px">このメールはデジタル生徒手帳のお問い合わせシステムから自動送信されています。<br>ご不明な点がございましたら、再度お問い合わせフォームよりご連絡ください。</p>
+    <a href="${base}" style="display:inline-block;background:#1a2744;color:#fff;padding:10px 22px;border-radius:8px;text-decoration:none;font-size:13px;font-weight:600;margin-top:8px">デジタル生徒手帳を開く</a>
+  </div>
+</div></body></html>`
+
+  const r = await resend(env, { to: recipientEmail, subject: `【回答】${subject || 'お問い合わせ'}`, html })
+  if (!r.ok) {
+    const detail = await r.text().catch(() => 'Unknown error')
+    console.error('[send-reply] Resend API error:', r.status, detail)
     return json({ error: 'Email send failed', detail, status: r.status }, 500)
   }
   return json({ ok: true })


### PR DESCRIPTION
## 変更内容

### 校章画像の修正
- ローディング画面とホームの手帳表紙の校章画像で `filter:brightness(0) invert(1)` を削除し、元の画像が正しく表示されるように修正
- トップページ左上のヘッダー部分は既に正常なのでそのまま

### 公欠申請の事由詳細入力
- 事由が「部活動」の場合は「部活動名」入力ボックスを表示
- 事由が「その他」の場合は「内容」入力ボックスを表示
- `reasonDetail` フィールドを Firestore・先生用ダッシュボード・管理画面に反映

### メール通知の日本語化
- 担任・顧問に送信される承認依頼メールを全て日本語に翻訳
- 公欠承認完了メールを日本語に翻訳
- メールの件名も日本語化（`【公欠申請】` / `【承認完了】`）

### 全文検索の拡充
- 歴代校長データを検索インデックスに追加（既に歌詞・沿革・各規定は対応済み）
- AI コンテキストにも歴代校長・歌詞・沿革データを追加

### 管理ダッシュボードのアクセス制御
- ログイン後に Firestore の `users` コレクションで `role === 'admin'` を検証
- 管理者以外がログインした場合はエラーメッセージを表示しログアウト

### ユーザー管理機能
- 管理ダッシュボードに「ユーザー一覧」セクションを追加
- ロール（生徒/先生/管理者）・学年・クラスでのフィルタリング
- 名前・メールでのテキスト検索
- ユーザー情報の編集（氏名・ロール・学年・クラス・番号）
- ユーザー登録情報の削除

### UI/UX改善
- `.pg-header` に `padding-top: 40px` を追加
- テーマ切替を `localStorage` に保存し、再読み込み後も状態を保持
- URL に `#page` 形式のハッシュを付加し、ページ遷移を保持
- ブラウザの戻る・進むボタンに対応（`popstate` イベント）

### 承認完了メール
- 「手帳を開く」ボタンのリンク先を `/#mypage` に変更

### お問い合わせ返信メール送信
- 管理ダッシュボードに「📧 メールで送信」ボタンを追加
- Workers に `/send-reply` エンドポイントを追加
- Resend API 経由で実際にメール送信

### 先生の登録画面
- プレースホルダーを「鈴木 先生」→「鈴木 太郎」に変更
- 「※先生は付けずにフルネームで入力してください」の注釈を追加

### Firestore セキュリティルール
- `isAdmin()` ヘルパー関数を追加
- ユーザーコレクションで管理者は全ユーザーの読み取り・更新・削除が可能に