### PR TITLE
feat: 複数の改善とmito1-tetyo.techへのドメイン移行

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -39,11 +39,11 @@ button,input,textarea,select{font-family:'Noto Sans JP',sans-serif}
   text-align:center;margin-bottom:28px;
 }
 .login-crest{
-  width:52px;height:52px;background:var(--navy);border-radius:50%;
-  display:flex;align-items:center;justify-content:center;
-  font-family:'Noto Serif JP',serif;font-size:11px;font-weight:700;
-  color:white;margin:0 auto 12px;
+  width:52px;height:52px;
+  border-radius:50%;overflow:hidden;
+  margin:0 auto 12px;
 }
+.login-crest img{width:100%;height:100%;object-fit:contain;}
 .login-title{font-family:'Noto Serif JP',serif;font-size:17px;font-weight:600;color:var(--navy)}
 .login-sub{font-size:11px;color:var(--text-3);margin-top:3px}
 .form-group{margin-bottom:16px}
@@ -82,10 +82,11 @@ button,input,textarea,select{font-family:'Noto Sans JP',sans-serif}
   display:flex;align-items:center;gap:9px;flex:1;
 }
 .adm-crest{
-  width:30px;height:30px;background:rgba(255,255,255,.12);
-  border-radius:50%;display:flex;align-items:center;justify-content:center;
-  font-family:'Noto Serif JP',serif;font-size:9px;color:white;font-weight:700;
+  width:30px;height:30px;
+  border-radius:50%;overflow:hidden;
+  display:flex;align-items:center;justify-content:center;
 }
+.adm-crest img{width:100%;height:100%;object-fit:contain;}
 .adm-brand-name{font-family:'Noto Serif JP',serif;font-size:13px;color:rgba(255,255,255,.95);font-weight:600}
 .adm-brand-badge{
   font-size:9.5px;background:var(--enjii);color:white;
@@ -332,18 +333,76 @@ button,input,textarea,select{font-family:'Noto Sans JP',sans-serif}
 @keyframes spin{to{transform:rotate(360deg)}}
 
 /* Dashboard */
-.dash-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:14px;margin-bottom:28px}
+.dash-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:16px;margin-bottom:28px}
 .dash-card{
   background:var(--surface);border:1.5px solid var(--border);
-  border-radius:var(--r);padding:18px 20px;
-  display:flex;flex-direction:column;gap:6px;
+  border-radius:var(--r-lg);padding:0;
+  display:flex;flex-direction:column;
+  transition:transform .15s, box-shadow .15s;
+  overflow:hidden;
 }
-.dash-card-num{font-size:28px;font-weight:700;color:var(--navy);font-family:'Noto Serif JP',serif}
-.dash-card-label{font-size:12px;color:var(--text-3)}
+.dash-card:hover{transform:translateY(-2px);box-shadow:var(--shadow-md)}
+.dash-card-top{
+  display:flex;align-items:center;gap:14px;
+  padding:18px 20px 14px;
+}
+.dash-card-icon{
+  width:44px;height:44px;border-radius:11px;
+  display:flex;align-items:center;justify-content:center;
+  flex-shrink:0;
+}
+.dash-card-icon svg{width:20px;height:20px;stroke:#fff;fill:none;stroke-width:1.8}
+.dash-card-info{flex:1;min-width:0}
+.dash-card-num{font-size:26px;font-weight:700;color:var(--navy);font-family:'Noto Serif JP',serif;line-height:1.2}
+.dash-card-label{font-size:12px;color:var(--text-3);margin-top:2px}
+.dash-card-bottom{
+  padding:10px 20px;border-top:1px solid var(--border-2);
+  display:flex;align-items:center;justify-content:space-between;
+  background:var(--surface2);
+}
 .dash-card-link{
   font-size:11.5px;color:var(--enjii);cursor:pointer;
-  margin-top:4px;display:inline-block;
+  display:inline-flex;align-items:center;gap:4px;
+  font-weight:500;transition:color .15s;
 }
+.dash-card-link:hover{color:var(--navy)}
+.dash-card-link svg{width:12px;height:12px;stroke:currentColor;fill:none;stroke-width:2.5}
+.dash-card-tag{
+  font-size:9.5px;font-weight:600;color:var(--text-3);
+  background:var(--surface);padding:2px 8px;border-radius:10px;
+}
+
+/* Dashboard summary row */
+.dash-summary{
+  display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:14px;
+  margin-bottom:22px;
+}
+.dash-summary-card{
+  background:var(--surface);border:1.5px solid var(--border);
+  border-radius:var(--r);padding:16px 20px;
+  display:flex;align-items:center;gap:14px;
+}
+.dash-summary-icon{
+  width:38px;height:38px;border-radius:9px;
+  display:flex;align-items:center;justify-content:center;
+  flex-shrink:0;
+}
+.dash-summary-icon svg{width:18px;height:18px;stroke:#fff;fill:none;stroke-width:2}
+.dash-summary-info{flex:1}
+.dash-summary-num{font-size:20px;font-weight:700;color:var(--text);line-height:1.2}
+.dash-summary-label{font-size:11px;color:var(--text-3)}
+.dash-welcome{
+  margin-bottom:24px;padding:22px 26px;
+  background:linear-gradient(135deg,var(--navy) 0%,#253a78 100%);
+  border-radius:var(--r-lg);color:white;position:relative;overflow:hidden;
+}
+.dash-welcome::after{
+  content:'';position:absolute;right:-30px;top:-30px;
+  width:140px;height:140px;border-radius:50%;
+  background:rgba(255,255,255,.05);
+}
+.dash-welcome-title{font-family:'Noto Serif JP',serif;font-size:18px;font-weight:600;margin-bottom:4px}
+.dash-welcome-sub{font-size:12px;color:rgba(255,255,255,.65)}
 </style>
 </head>
 <body>
@@ -352,7 +411,7 @@ button,input,textarea,select{font-family:'Noto Sans JP',sans-serif}
 <div id="loginScreen">
   <div class="login-box">
     <div class="login-logo">
-      <div class="login-crest">校章</div>
+      <div class="login-crest"><img src="/crest_touka.png" alt="校章"></div>
       <div class="login-title">管理者ポータル</div>
       <div class="login-sub">水戸第一高等学校 デジタル生徒手帳</div>
     </div>
@@ -374,7 +433,7 @@ button,input,textarea,select{font-family:'Noto Sans JP',sans-serif}
 <div id="appShell">
   <header class="adm-header">
     <div class="adm-header-brand">
-      <div class="adm-crest">校章</div>
+      <div class="adm-crest"><img src="/crest_touka.png" alt="校章"></div>
       <span class="adm-brand-name">デジタル生徒手帳</span>
       <span class="adm-brand-badge">管理者</span>
     </div>

--- a/index.html
+++ b/index.html
@@ -9,10 +9,10 @@
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 <meta name="apple-mobile-web-app-title" content="水一手帳">
 <title>デジタル生徒手帳 - 水戸第一高等学校</title>
-<link rel="manifest" href="/mito1-digital-studenthandbook/manifest.json">
-<link rel="icon" type="image/png" sizes="192x192" href="/mito1-digital-studenthandbook/icons/icon-192.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/mito1-digital-studenthandbook/icons/icon-32.png">
-<link rel="apple-touch-icon" href="/mito1-digital-studenthandbook/icons/icon-192.png">
+<link rel="manifest" href="/manifest.json">
+<link rel="icon" type="image/png" sizes="192x192" href="/icons/icon-192.png">
+<link rel="icon" type="image/png" sizes="32x32" href="/icons/icon-32.png">
+<link rel="apple-touch-icon" href="/icons/icon-192.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@400;500;600;700&family=Noto+Sans+JP:wght@300;400;500;600&display=swap" rel="stylesheet">
 <style>
@@ -977,7 +977,7 @@ select.cf-input{cursor:pointer}
 <div id="loading">
   <div class="load-stage">
     <!-- 校章画像 -->
-    <img class="load-crest-img" src="/mito1-digital-studenthandbook/crest.png" alt="校章">
+    <img class="load-crest-img" src="/crest_touka.png" alt="校章">
 
     <!-- 学校名 -->
     <div class="load-school-wrap">
@@ -1004,7 +1004,7 @@ select.cf-input{cursor:pointer}
   </button>
 
   <div class="header-brand" onclick="nav('home')">
-    <img class="brand-crest" src="/mito1-digital-studenthandbook/crest.png" alt="校章">
+    <img class="brand-crest" src="/crest_touka.png" alt="校章">
     <div class="brand-names">
       <span class="brand-main">デジタル生徒手帳</span>
       <span class="brand-sub">水戸第一高等学校</span>
@@ -1239,7 +1239,7 @@ select.cf-input{cursor:pointer}
     <div class="home-wrap">
       <div class="home-brand">
         <div class="home-book">
-          <img class="hb-crest" src="/mito1-digital-studenthandbook/crest.png" alt="校章">
+          <img class="hb-crest" src="/crest_touka.png" alt="校章">
           <div class="hb-ttl">生徒手帳</div>
           <div class="hb-div"></div>
           <div class="hb-school">茨城県立<br>水戸第一高等学校</div>
@@ -1588,7 +1588,7 @@ select.cf-input{cursor:pointer}
         <svg viewBox="0 0 24 24" style="width:48px;height:48px;stroke:var(--text-3);fill:none;stroke-width:1.5;margin-bottom:16px"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
         <div style="font-size:15px;font-weight:600;color:var(--text);margin-bottom:8px">ログインが必要です</div>
         <p style="font-size:13px;color:var(--text-3);margin-bottom:20px">公欠申請を行うにはアカウントが必要です。</p>
-        <a href="/mito1-digital-studenthandbook/auth.html" class="btn-navy" style="display:inline-block;padding:11px 28px;border-radius:8px;font-weight:600;font-size:14px;background:var(--navy);color:#fff">ログイン / 新規登録</a>
+        <a href="/auth.html" class="btn-navy" style="display:inline-block;padding:11px 28px;border-radius:8px;font-weight:600;font-size:14px;background:var(--navy);color:#fff">ログイン / 新規登録</a>
       </div>
     </div>
     <!-- ログイン済みフォーム -->
@@ -1663,7 +1663,7 @@ select.cf-input{cursor:pointer}
     <div id="mypageLoginRequired" style="display:none">
       <div class="card" style="text-align:center;padding:40px 24px">
         <div style="font-size:15px;font-weight:600;color:var(--text);margin-bottom:8px">ログインが必要です</div>
-        <a href="/mito1-digital-studenthandbook/auth.html" class="btn-navy" style="display:inline-block;padding:11px 28px;border-radius:8px;font-weight:600;font-size:14px;background:var(--navy);color:#fff">ログイン</a>
+        <a href="/auth.html" class="btn-navy" style="display:inline-block;padding:11px 28px;border-radius:8px;font-weight:600;font-size:14px;background:var(--navy);color:#fff">ログイン</a>
       </div>
     </div>
     <!-- ログイン済み -->
@@ -2190,7 +2190,7 @@ document.head.appendChild(style);
 
 // Service Worker 登録
 if('serviceWorker' in navigator){
-  navigator.serviceWorker.register('/mito1-digital-studenthandbook/sw.js')
+  navigator.serviceWorker.register('/sw.js')
     .catch(e=>console.warn('SW registration failed:',e));
 }
 

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+mito1-tetyo.tech

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,20 +2,20 @@
   "name": "水戸第一高等学校 デジタル生徒手帳",
   "short_name": "水一手帳",
   "description": "茨城県立水戸第一高等学校 デジタル生徒手帳",
-  "start_url": "/mito1-digital-studenthandbook/",
+  "start_url": "/",
   "display": "standalone",
   "orientation": "portrait",
   "background_color": "#1a2744",
   "theme_color": "#1a2744",
   "icons": [
     {
-      "src": "/mito1-digital-studenthandbook/icons/icon-192.png",
+      "src": "/icons/icon-192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/mito1-digital-studenthandbook/icons/icon-512.png",
+      "src": "/icons/icon-512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any maskable"

--- a/public/sw.js
+++ b/public/sw.js
@@ -3,7 +3,7 @@
 // 修正: Response.clone() を非同期処理の前に呼ぶ
 // ================================================
 const CACHE = 'mito1-v3';  // バージョン上げて古いキャッシュを強制削除
-const BASE  = '/mito1-digital-studenthandbook';
+const BASE  = '';
 
 self.addEventListener('install', () => self.skipWaiting());
 

--- a/src/admin/main.js
+++ b/src/admin/main.js
@@ -90,6 +90,8 @@ onAuthStateChanged(auth, async user => {
     document.getElementById('appShell').classList.add('show')
     document.getElementById('headerUser').textContent = user.email
     loadSection('dashboard')
+    // Load badge counts immediately on login
+    loadBadgeCounts()
   } else {
     document.getElementById('loginScreen').classList.remove('hide')
     document.getElementById('appShell').classList.remove('show')
@@ -190,27 +192,138 @@ function emptyState(msg = 'まだデータがありません') {
 // =============================================
 async function loadDashboard() {
   const grid = document.getElementById('dashGrid')
+
+  const DASH_ICONS = {
+    rules:            { bg: '#1a2744', svg: '<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/>' },
+    special:          { bg: '#6c3483', svg: '<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="12" y1="11" x2="12" y2="17"/><line x1="9" y1="14" x2="15" y2="14"/>' },
+    events:           { bg: '#2471a3', svg: '<rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/>' },
+    history:          { bg: '#1e8449', svg: '<path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/>' },
+    principals:       { bg: '#d4ac0d', svg: '<path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/>' },
+    songs:            { bg: '#cb4335', svg: '<path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/>' },
+    curriculum:       { bg: '#117a65', svg: '<rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/>' },
+    'council-charter':{ bg: '#8b1a2c', svg: '<path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>' },
+    'council-rules':  { bg: '#7d6608', svg: '<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/>' },
+  }
+
   const sections = [
-    { col: 'rules',           label: '諸規定（本則）',     sec: 'rules' },
-    { col: 'special',         label: '特別教育活動',       sec: 'special' },
-    { col: 'events',          label: '年間主要行事',       sec: 'events' },
-    { col: 'history',         label: '本校の沿革',         sec: 'history' },
-    { col: 'principals',      label: '歴代校長',           sec: 'principals' },
-    { col: 'songs',           label: '歌詞',               sec: 'songs' },
-    { col: 'curriculum',      label: '教育課程',           sec: 'curriculum' },
-    { col: 'council-charter', label: '知道生徒会憲章',     sec: 'council-charter' },
-    { col: 'council-rules',   label: '生徒会関係諸規定',   sec: 'council-rules' },
+    { col: 'rules',           label: '諸規定（本則）',     sec: 'rules',           unit: '条' },
+    { col: 'special',         label: '特別教育活動',       sec: 'special',          unit: '条' },
+    { col: 'events',          label: '年間主要行事',       sec: 'events',           unit: '件' },
+    { col: 'history',         label: '本校の沿革',         sec: 'history',          unit: '件' },
+    { col: 'principals',      label: '歴代校長',           sec: 'principals',       unit: '名' },
+    { col: 'songs',           label: '歌詞',               sec: 'songs',            unit: '曲' },
+    { col: 'curriculum',      label: '教育課程',           sec: 'curriculum',       unit: '科目' },
+    { col: 'council-charter', label: '知道生徒会憲章',     sec: 'council-charter',  unit: '条' },
+    { col: 'council-rules',   label: '生徒会関係諸規定',   sec: 'council-rules',    unit: '条' },
   ]
   const counts = await Promise.all(
     sections.map(s => getDocs(collection(db, s.col)).then(sn => sn.size).catch(() => 0))
   )
-  grid.innerHTML = sections.map((s, i) => `
-    <div class="dash-card">
-      <div class="dash-card-num">${counts[i]}</div>
-      <div class="dash-card-label">${s.label}</div>
-      <span class="dash-card-link" data-nav="${s.sec}">管理する →</span>
+
+  // Also fetch inquiries/cases counts for the summary
+  let inquiryNewCount = 0, casePendingCount = 0, totalUsers = 0
+  try {
+    const [iqSnap, csSnap, usSnap] = await Promise.all([
+      getDocs(collection(db, 'inquiries')),
+      getDocs(collection(db, 'cases')),
+      getDocs(collection(db, 'users')),
+    ])
+    inquiryNewCount = iqSnap.docs.filter(d => d.data().status === 'new').length
+    casePendingCount = csSnap.docs.filter(d => ['pending_supervisor','pending_homeroom'].includes(d.data().status)).length
+    totalUsers = usSnap.size
+  } catch(e) { /* ignore */ }
+
+  const totalContent = counts.reduce((a, b) => a + b, 0)
+
+  grid.innerHTML = `
+    <div class="dash-welcome">
+      <div class="dash-welcome-title">管理者ダッシュボード</div>
+      <div class="dash-welcome-sub">水戸第一高等学校 デジタル生徒手帳の全コンテンツを管理できます</div>
     </div>
-  `).join('')
+
+    <div class="dash-summary">
+      <div class="dash-summary-card">
+        <div class="dash-summary-icon" style="background:linear-gradient(135deg,#1a2744,#253a78)">
+          <svg viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+        </div>
+        <div class="dash-summary-info">
+          <div class="dash-summary-num">${totalContent}</div>
+          <div class="dash-summary-label">全コンテンツ数</div>
+        </div>
+      </div>
+      <div class="dash-summary-card" style="cursor:pointer" data-nav="inquiries">
+        <div class="dash-summary-icon" style="background:linear-gradient(135deg,#c0392b,#e74c3c)">
+          <svg viewBox="0 0 24 24"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+        </div>
+        <div class="dash-summary-info">
+          <div class="dash-summary-num">${inquiryNewCount}</div>
+          <div class="dash-summary-label">未対応のお問い合わせ</div>
+        </div>
+      </div>
+      <div class="dash-summary-card" style="cursor:pointer" data-nav="cases">
+        <div class="dash-summary-icon" style="background:linear-gradient(135deg,#856404,#d4ac0d)">
+          <svg viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="12" y1="18" x2="12" y2="12"/><line x1="9" y1="15" x2="15" y2="15"/></svg>
+        </div>
+        <div class="dash-summary-info">
+          <div class="dash-summary-num">${casePendingCount}</div>
+          <div class="dash-summary-label">承認待ち公欠申請</div>
+        </div>
+      </div>
+      <div class="dash-summary-card" style="cursor:pointer" data-nav="users">
+        <div class="dash-summary-icon" style="background:linear-gradient(135deg,#1e8449,#27ae60)">
+          <svg viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+        </div>
+        <div class="dash-summary-info">
+          <div class="dash-summary-num">${totalUsers}</div>
+          <div class="dash-summary-label">登録ユーザー</div>
+        </div>
+      </div>
+    </div>
+
+    <div style="font-size:13px;font-weight:600;color:var(--text);margin-bottom:12px;padding-left:2px">コンテンツ管理</div>
+    <div class="dash-grid" style="margin-bottom:0">
+      ${sections.map((s, i) => {
+        const ic = DASH_ICONS[s.col] || DASH_ICONS.rules
+        return `
+          <div class="dash-card">
+            <div class="dash-card-top">
+              <div class="dash-card-icon" style="background:${ic.bg}">
+                <svg viewBox="0 0 24 24">${ic.svg}</svg>
+              </div>
+              <div class="dash-card-info">
+                <div class="dash-card-num">${counts[i]}</div>
+                <div class="dash-card-label">${s.label}</div>
+              </div>
+            </div>
+            <div class="dash-card-bottom">
+              <span class="dash-card-link" data-nav="${s.sec}">管理する <svg viewBox="0 0 24 24"><polyline points="9 18 15 12 9 6"/></svg></span>
+              <span class="dash-card-tag">${counts[i]}${s.unit}</span>
+            </div>
+          </div>`
+      }).join('')}
+    </div>
+  `
+}
+
+// =============================================
+// BADGE COUNTS (load on site access)
+// =============================================
+async function loadBadgeCounts() {
+  try {
+    // Inquiries badge
+    const iqSnap = await getDocs(query(collection(db, 'inquiries'), orderBy('createdAt', 'desc')))
+    const newCount = iqSnap.docs.filter(d => d.data().status === 'new').length
+    const iqBadge = document.getElementById('inquiryBadge')
+    if (iqBadge) { iqBadge.textContent = newCount; iqBadge.style.display = newCount ? '' : 'none' }
+  } catch(e) { /* ignore */ }
+
+  try {
+    // Cases badge
+    const csSnap = await getDocs(query(collection(db, 'cases'), orderBy('createdAt', 'desc')))
+    const pending = csSnap.docs.filter(d => ['pending_supervisor','pending_homeroom'].includes(d.data().status)).length
+    const csBadge = document.getElementById('casesBadge')
+    if (csBadge) { csBadge.textContent = pending; csBadge.style.display = pending ? '' : 'none' }
+  } catch(e) { /* ignore */ }
 }
 
 // =============================================
@@ -344,7 +457,7 @@ function renderArticleList(containerId) {
         </div>
         <div class="item-card-body">
           <div class="item-body-text">${item.body || ''}</div>
-          ${(item.items||[]).length ? `<div style="margin-top:8px;font-size:12px;color:var(--text-3)">${item.items.length}項あり</div>` : ''}
+          ${(item.items||[]).length ? `<div style="margin-top:8px;font-size:12px;color:var(--text-3)">${item.items.filter(it => !/^[\s\t　]+/.test(it) && !/^[ア-ン][\s　.]/.test(it.trim())).length}項あり${item.items.some(it => /^[\s\t　]+/.test(it) || /^[ア-ン][\s　.]/.test(it.trim())) ? '（サブ項目含む）' : ''}</div>` : ''}
         </div>
       </div>
     `).join('')
@@ -771,8 +884,9 @@ const articleForm = (type) => ({
       <textarea id="f_body" rows="4" placeholder="条文の本文を入力..."></textarea>
     </div>
     <div class="form-row">
-      <label>項（1行1項。空行で区切り）</label>
-      <textarea id="f_items" rows="6" placeholder="1 授業に関すること&#10;2 施設の利用に関すること"></textarea>
+      <label>項（1行1項。サブ項目はスペースで字下げ、ア イ ウ...で始める）</label>
+      <textarea id="f_items" rows="8" placeholder="1 授業に関すること&#10;  ア 遅刻について&#10;  イ 欠席について&#10;2 施設の利用に関すること"></textarea>
+      <div style="font-size:10.5px;color:var(--text-3);margin-top:3px">サブ項目はスペースで字下げするか「ア」「イ」等で始めてください</div>
     </div>
     <div class="form-row">
       <label>並び順</label>
@@ -934,7 +1048,7 @@ window.loadInquiries = async function() {
               style="font-size:11px;padding:6px 12px;border:none;border-radius:6px;background:var(--navy);cursor:pointer;color:#fff">
               返信内容を保存
             </button>
-            <button onclick="sendReplyEmail('${item.id}')"
+            <button onclick="sendReplyEmail('${item.id}', event)"
               style="font-size:11px;padding:6px 12px;border:none;border-radius:6px;background:#27ae60;cursor:pointer;color:#fff">
               📧 メールで送信
             </button>
@@ -992,7 +1106,7 @@ window.saveReply = async function(id) {
 }
 
 // メールで返信を送信
-window.sendReplyEmail = async function(id) {
+window.sendReplyEmail = async function(id, evt) {
   const ta = document.getElementById('reply-'+id)
   if (!ta || !ta.value.trim()) { showToast('返信内容を入力してください'); return }
 
@@ -1002,9 +1116,11 @@ window.sendReplyEmail = async function(id) {
   const data = snap.data()
   if (!data.email) { showToast('送信先メールアドレスがありません'); return }
 
-  const btn = event.target
-  btn.disabled = true
-  btn.textContent = '送信中...'
+  const btn = evt ? evt.currentTarget : document.querySelector(`#inq-${id} button[onclick*="sendReplyEmail"]`)
+  if (btn) {
+    btn.disabled = true
+    btn.textContent = '送信中...'
+  }
 
   try {
     const res = await fetch(AI_URL + '/send-reply', {
@@ -1015,7 +1131,7 @@ window.sendReplyEmail = async function(id) {
         recipientName: data.name || '',
         subject: data.subject || 'お問い合わせ',
         replyBody: ta.value.trim(),
-        appBaseUrl: window.location.origin + '/mito1-digital-studenthandbook',
+        appBaseUrl: window.location.origin,
       })
     })
     if (!res.ok) {
@@ -1028,8 +1144,10 @@ window.sendReplyEmail = async function(id) {
     loadInquiries()
   } catch(e) {
     showToast('メール送信エラー: ' + e.message)
-    btn.disabled = false
-    btn.textContent = '📧 メールで送信'
+    if (btn) {
+      btn.disabled = false
+      btn.textContent = '📧 メールで送信'
+    }
   }
 }
 

--- a/src/approve.js
+++ b/src/approve.js
@@ -66,7 +66,7 @@ async function main() {
   if (!caseId) {
     render('❌', 'ケースIDを特定できません',
       'このリンクからケースを特定できませんでした。<br>' +
-      '<a href="/mito1-digital-studenthandbook/teacher.html" style="color:#1a2744;font-weight:600">先生用ダッシュボード</a>からログインして承認してください。')
+      '<a href="/teacher.html" style="color:#1a2744;font-weight:600">先生用ダッシュボード</a>からログインして承認してください。')
     return
   }
 
@@ -160,10 +160,10 @@ async function doProcess(processAction) {
       if (result.reason === 'already_processed') {
         render('⚠️', 'すでに処理済みです',
           'この申請はすでに処理されています。<br>ダッシュボードで最新の状況をご確認ください。',
-          `<a class="btn btn-back" style="display:block;margin-top:16px;text-decoration:none;padding:13px;border-radius:10px" href="/mito1-digital-studenthandbook/teacher.html">ダッシュボードへ</a>`)
+          `<a class="btn btn-back" style="display:block;margin-top:16px;text-decoration:none;padding:13px;border-radius:10px" href="/teacher.html">ダッシュボードへ</a>`)
       } else {
         render('❌', 'リンクが無効です', 'このリンクは有効期限切れか、すでに使用されています。<br>' +
-          '<a href="/mito1-digital-studenthandbook/teacher.html" style="color:#1a2744;font-weight:600">先生用ダッシュボード</a>から操作してください。')
+          '<a href="/teacher.html" style="color:#1a2744;font-weight:600">先生用ダッシュボード</a>から操作してください。')
       }
       return
     }

--- a/src/auth_page.js
+++ b/src/auth_page.js
@@ -1,6 +1,6 @@
 import { onAuth, login, registerStudent, registerTeacher, resetPassword, getCurrentProfile } from './auth.js'
 
-const BASE = '/mito1-digital-studenthandbook'
+const BASE = ''
 
 // ── UIを描画 ──────────────────────────────────────────────────────
 document.getElementById('mainCard').innerHTML = `

--- a/src/main.js
+++ b/src/main.js
@@ -121,6 +121,53 @@ async function loadSongs() {
 }
 
 // =============================================
+// 項目のサブアイテム対応レンダリング
+// 行頭がスペース/タブで始まる行 or ア〜ン で始まる行はサブアイテム
+// 構造: 章 > 条 > (1) > ア, イ
+// =============================================
+function renderItemsWithSubItems(items) {
+  if (!items || !items.length) return ''
+
+  // Parse items into groups: main items with optional sub-items
+  const groups = []
+  let mainIdx = 0
+
+  for (let i = 0; i < items.length; i++) {
+    const line = items[i]
+    const isSubItem = /^[\s\t　]+/.test(line) || /^[ア-ン][\s　.]/.test(line.trim())
+
+    if (isSubItem && groups.length > 0) {
+      // Attach as sub-item to the last main item
+      groups[groups.length - 1].subs.push(line.trim())
+    } else {
+      mainIdx++
+      groups.push({ idx: mainIdx, text: line, subs: [] })
+    }
+  }
+
+  return groups.map(g => `
+    <li class="item-row">
+      <span class="item-idx">${g.idx}</span>
+      <span>
+        ${g.text}
+        ${g.subs.length ? `
+          <ul class="sub-list">
+            ${g.subs.map(sub => {
+              // Extract label (ア, イ, etc.) if present
+              const match = sub.match(/^([ア-ン])\s*(.*)$/)
+              if (match) {
+                return `<li class="sub-row"><span class="sub-idx">${match[1]}</span><span>${match[2]}</span></li>`
+              }
+              return `<li class="sub-row"><span class="sub-idx">・</span><span>${sub}</span></li>`
+            }).join('')}
+          </ul>
+        ` : ''}
+      </span>
+    </li>
+  `).join('')
+}
+
+// =============================================
 // 条文（諸規定・特別教育活動・生徒会憲章・生徒会関係諸規定）
 // description（説明文/前文）やsection（総則/細則）にも対応
 // =============================================
@@ -178,12 +225,7 @@ function renderArticles(items, containerId, tocId, options = {}) {
           ${item.body ? `<div class="art-main">${item.body}</div>` : ''}
           ${(item.items || []).length ? `
             <ol class="items-list">
-              ${item.items.map((itm, i) => `
-                <li class="item-row">
-                  <span class="item-idx">${i + 1}</span>
-                  <span>${itm}</span>
-                </li>
-              `).join('')}
+              ${renderItemsWithSubItems(item.items)}
             </ol>
           ` : ''}
         </div>
@@ -585,7 +627,10 @@ function buildAIContext() {
       if (r.title) text += `（${r.title}）`
       if (r.chapter) text += ` [${r.chapter}]`
       if (r.body) text += `\n${r.body}`
-      if (r.items?.length) text += '\n' + r.items.map((it, i) => `  ${i + 1}. ${it}`).join('\n')
+      if (r.items?.length) text += '\n' + r.items.map(it => {
+        const isSubItem = /^[\s\t　]+/.test(it) || /^[ア-ン][\s　.]/.test(it.trim())
+        return isSubItem ? `      ${it.trim()}` : `  ${it}`
+      }).join('\n')
       lines.push(text)
     })
   }

--- a/src/teacher_page.js
+++ b/src/teacher_page.js
@@ -14,7 +14,7 @@ let allCases = []
 let myProfile = null
 
 onAuth(async user => {
-  if (!user) { location.href = '/mito1-digital-studenthandbook/auth.html'; return }
+  if (!user) { location.href = '/auth.html'; return }
   try {
     myProfile = await getCurrentProfile(user)
     if (!myProfile) {
@@ -155,7 +155,7 @@ window.handleReject = async function(caseId, step) {
 
 window.doLogout = async function() {
   await logout()
-  location.href = '/mito1-digital-studenthandbook/auth.html'
+  location.href = '/auth.html'
 }
 
 function esc(s) { return String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;') }

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,7 +5,7 @@ import { dirname, resolve } from 'path'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
-  base: '/mito1-digital-studenthandbook/',
+  base: '/',
   build: {
     rollupOptions: {
       input: {

--- a/workers/index.js
+++ b/workers/index.js
@@ -7,7 +7,7 @@
  * Secrets (Settings > Variables and Secrets):
  *   GEMINI_API_KEY  -- Gemini API key (Secret)
  *   RESEND_API_KEY  -- Resend API key (Secret)
- *   APP_BASE_URL    -- https://ryuto-devs.github.io/mito1-digital-studenthandbook (Plain text)
+ *   APP_BASE_URL    -- https://mito1-tetyo.tech (Plain text)
  *   RESEND_FROM     -- Verified sender (Plain text, e.g. "mito1-handbook <noreply@yourdomain.com>")
  *                      If not set, falls back to "mito1-handbook <onboarding@resend.dev>"
  *                      NOTE: onboarding@resend.dev can ONLY deliver to the Resend account owner's email.
@@ -36,7 +36,7 @@ export default {
       const caseId = url.searchParams.get('caseId')
       const token  = url.searchParams.get('token')
       const action = url.searchParams.get('action') || 'approve'
-      const base   = env.APP_BASE_URL || 'https://ryuto-devs.github.io/mito1-digital-studenthandbook'
+      const base   = env.APP_BASE_URL || 'https://mito1-tetyo.tech'
       if (!token) return new Response('Token is invalid', { status: 400 })
 
       let redirectUrl = `${base}/approve.html?token=${encodeURIComponent(token)}&action=${action}`
@@ -146,7 +146,7 @@ async function sendApproval(body, env) {
     return json({ error: 'recipientEmail is required' }, 400)
   }
 
-  const base     = appBaseUrl || env.APP_BASE_URL || 'https://ryuto-devs.github.io/mito1-digital-studenthandbook'
+  const base     = appBaseUrl || env.APP_BASE_URL || 'https://mito1-tetyo.tech'
   const datesStr = (dates || []).join(', ')
   const roleName = recipientRole === 'supervisor' ? '顧問' : '担任'
   const reasonDisplay = reasonDetail ? `${reason}（${reasonDetail}）` : (reason || '部活動')
@@ -160,7 +160,10 @@ async function sendApproval(body, env) {
   const html = `<!DOCTYPE html><html lang="ja"><head><meta charset="UTF-8"></head>
 <body style="font-family:'Helvetica Neue',Arial,'Noto Sans JP',sans-serif;background:#f5f5f5;padding:24px;margin:0">
 <div style="max-width:560px;margin:0 auto;background:#fff;border-radius:12px;overflow:hidden;box-shadow:0 2px 12px rgba(0,0,0,.08)">
-  <div style="background:#1a2744;padding:20px 28px"><div style="color:#fff;font-size:18px;font-weight:700">水戸第一高等学校</div><div style="color:#a0b0cc;font-size:12px;margin-top:2px">デジタル生徒手帳 公欠申請システム</div></div>
+  <div style="background:#1a2744;padding:20px 28px;display:flex;align-items:center;gap:14px">
+    <img src="${base}/icons/icon-192.png" alt="" style="width:40px;height:40px;border-radius:8px" />
+    <div><div style="color:#fff;font-size:18px;font-weight:700">水戸第一高等学校</div><div style="color:#a0b0cc;font-size:12px;margin-top:2px">デジタル生徒手帳 公欠申請システム</div></div>
+  </div>
   <div style="padding:28px">
     <p style="color:#333;font-size:15px;margin:0 0 16px">${roleName}の先生<br><br>以下の公欠申請の承認をお願いいたします。</p>
     ${supNote}
@@ -201,7 +204,10 @@ async function sendComplete(body, env) {
   const html = `<!DOCTYPE html><html lang="ja"><head><meta charset="UTF-8"></head>
 <body style="font-family:'Helvetica Neue',Arial,'Noto Sans JP',sans-serif;background:#f5f5f5;padding:24px;margin:0">
 <div style="max-width:560px;margin:0 auto;background:#fff;border-radius:12px;overflow:hidden;box-shadow:0 2px 12px rgba(0,0,0,.08)">
-  <div style="background:#1a2744;padding:20px 28px"><div style="color:#fff;font-size:18px;font-weight:700">水戸第一高等学校</div><div style="color:#a0b0cc;font-size:12px;margin-top:2px">デジタル生徒手帳 公欠申請システム</div></div>
+  <div style="background:#1a2744;padding:20px 28px;display:flex;align-items:center;gap:14px">
+    <img src="${base}/icons/icon-192.png" alt="" style="width:40px;height:40px;border-radius:8px" />
+    <div><div style="color:#fff;font-size:18px;font-weight:700">水戸第一高等学校</div><div style="color:#a0b0cc;font-size:12px;margin-top:2px">デジタル生徒手帳 公欠申請システム</div></div>
+  </div>
   <div style="padding:28px;text-align:center">
     <div style="font-size:48px;margin-bottom:12px">&#10004;</div>
     <div style="font-size:18px;font-weight:700;color:#1a2744;margin-bottom:8px">公欠申請が承認されました</div>
@@ -236,11 +242,15 @@ async function sendReply(body, env) {
 
   const base = appBaseUrl || env.APP_BASE_URL || ''
   const replyText = (replyBody || '').replace(/\n/g, '<br>')
+  const iconUrl = base ? `${base}/icons/icon-192.png` : ''
 
   const html = `<!DOCTYPE html><html lang="ja"><head><meta charset="UTF-8"></head>
 <body style="font-family:'Helvetica Neue',Arial,'Noto Sans JP',sans-serif;background:#f5f5f5;padding:24px;margin:0">
 <div style="max-width:560px;margin:0 auto;background:#fff;border-radius:12px;overflow:hidden;box-shadow:0 2px 12px rgba(0,0,0,.08)">
-  <div style="background:#1a2744;padding:20px 28px"><div style="color:#fff;font-size:18px;font-weight:700">水戸第一高等学校</div><div style="color:#a0b0cc;font-size:12px;margin-top:2px">デジタル生徒手帳 お問い合わせ回答</div></div>
+  <div style="background:#1a2744;padding:20px 28px;display:flex;align-items:center;gap:14px">
+    ${iconUrl ? `<img src="${iconUrl}" alt="" style="width:40px;height:40px;border-radius:8px" />` : ''}
+    <div><div style="color:#fff;font-size:18px;font-weight:700">水戸第一高等学校</div><div style="color:#a0b0cc;font-size:12px;margin-top:2px">デジタル生徒手帳 お問い合わせ回答</div></div>
+  </div>
   <div style="padding:28px">
     <p style="color:#333;font-size:15px;margin:0 0 16px">${recipientName || ''} 様<br><br>お問い合わせいただきありがとうございます。<br>以下の通り回答いたします。</p>
     <div style="background:#f8f9fa;border-radius:8px;padding:16px 18px;margin:16px 0;font-size:14px;color:#333;line-height:1.8;border-left:4px solid #1a2744">


### PR DESCRIPTION
## 変更内容

### 1. メール送信のバグ修正
- `sendReplyEmail` の `TypeError: Cannot read properties of undefined (reading 'target')` を修正
- `event` パラメータを正しく渡すように変更

### 2. 校章画像の置換
- ローディング画面の校章を `crest_touka.png` に変更
- ヘッダーの校章を `crest_touka.png` に変更
- ホーム画面の浮いている手帳の校章を `crest_touka.png` に変更
- 管理者ダッシュボードのログイン画面/ヘッダーの校章を `crest_touka.png` に変更

### 3. 管理者ダッシュボードの再設計
- ウェルカムバナー（グラデーション付き）を追加
- サマリーカード（全コンテンツ数、未対応お問い合わせ、承認待ち公欠、登録ユーザー数）を追加
- 各セクションカードにアイコン、単位ラベル、ホバーエフェクトを追加

### 4. お問い合わせ/ケース管理のバッジ修正
- ログイン時にバッジカウントを即座に読み込むように変更

### 5. 諸規定のサブアイテム対応
- 章 > 条 > (1) > ア, イ の4階層構造をサポート
- 管理画面のフォームにサブアイテムの入力方法を説明追加
- フロントエンドのレンダリングを対応

### 6. メールアイコンの追加
- 全メールテンプレートにアプリアイコン（icon-192.png）を表示

### 7. ドメイン移行
- ベースパスを `/mito1-digital-studenthandbook/` から `/` に変更
- Workers の APP_BASE_URL を `https://mito1-tetyo.tech` に変更
- CNAME ファイル追加（GitHub Pages カスタムドメイン用）
- vite.config.js, manifest.json, sw.js, 全ソースファイルのパスを更新

### 注意事項
- GitHub Pages の設定でカスタムドメイン `mito1-tetyo.tech` の設定が必要です
- Cloudflare Workers の `APP_BASE_URL` 環境変数を `https://mito1-tetyo.tech` に更新してください